### PR TITLE
Update .gitignore for Node/TS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,30 @@
-/node_modules
+# Node dependencies
+node_modules/
+
+# Build outputs
+/dist/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+*.log
+
+# Editor directories and OS files
+.vscode/
+.idea/
+.DS_Store
+*.swp
+
+# TypeScript build info
+*.tsbuildinfo
+
+# Environment files
+.env
+.env.*
+
+# Lock files
 package-lock.json
+yarn.lock
+pnpm-lock.yaml


### PR DESCRIPTION
## Summary
- expand the `.gitignore` with standard Node.js and TypeScript exclusions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a083ea4f0832795a8eecc76d8f6c8