### PR TITLE
Remove reusePort option for server

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -84,7 +84,6 @@ app.use((req, res, next) => {
   server.listen({
     port,
     host: "0.0.0.0",
-    reusePort: true,
   }, () => {
     log(`serving on port ${port}`);
   });


### PR DESCRIPTION
## Summary
- fix server startup on macOS by removing reusePort option

## Testing
- `npm run build` *(fails: Could not load attached_assets/...)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_688a083bfecc832784d2eef7c15b2f77