### PR TITLE
design: slim footer to a sign-off, remove contact-link duplication

### DIFF
--- a/client/src/constants/strings.ts
+++ b/client/src/constants/strings.ts
@@ -17,9 +17,8 @@ export const PERSONAL_INFO = {
 // Job Titles & Roles
 export const ROLES = {
   PRIMARY: 'R&D Team Leader',
-  SUBTITLE: 'Strategic Engineering Leader',
-  FULL_SUBTITLE: 'R&D Team Leader | Strategic Engineering Leader',
-  LIST: ['R&D Team Leader', 'Strategic Engineering Leader'],
+  FULL_SUBTITLE: 'R&D Team Leader',
+  LIST: ['R&D Team Leader'],
 } as const;
 
 // Taglines & Quotes

--- a/client/src/constants/strings.ts
+++ b/client/src/constants/strings.ts
@@ -17,8 +17,8 @@ export const PERSONAL_INFO = {
 // Job Titles & Roles
 export const ROLES = {
   PRIMARY: 'R&D Team Leader',
-  FULL_SUBTITLE: 'R&D Team Leader',
-  LIST: ['R&D Team Leader'],
+  FULL_SUBTITLE: 'R&D Leader',
+  LIST: ['R&D Leader'],
 } as const;
 
 // Taglines & Quotes
@@ -209,7 +209,8 @@ export const CONSOLE_SDK = {
 
   EXPERIENCE_TITLE: '🗓  Experience — the timeline',
   EXPERIENCE: [
-    { role: 'R&D Team Leader', company: 'Swish.ai', period: '2024 → now', focus: 'AI-driven IT workflow optimization' },
+    { role: 'R&D Team Leader', company: 'Zencity', period: '2026 → now', focus: 'Just getting started — magic in progress' },
+    { role: 'R&D Team Leader', company: 'Swish.ai', period: '2024 → 2025', focus: 'AI-driven IT workflow optimization' },
     { role: 'R&D Team Leader', company: 'Perion Network', period: '2021 → 2024', focus: 'Led 5; microservices + MongoDB' },
     { role: 'Full-Stack Developer', company: 'Perion Network', period: '2018 → 2021', focus: 'React · Next.js · Node' },
     { role: 'Full-Stack Developer', company: 'Mind Connect', period: '2016 → 2018', focus: 'Call-center platform' },

--- a/client/src/constants/strings.ts
+++ b/client/src/constants/strings.ts
@@ -92,7 +92,7 @@ export const CONSOLE_MESSAGES = {
   FUN_DARK: '   • Dark mode with custom CSS variables',
   
   ABOUT_TITLE: '🎯 About Victoria:',
-  ABOUT_EXPERIENCE: "   • 10+ years in tech (Full Stack → Team Lead → R&D Leader)",
+  ABOUT_EXPERIENCE: "   • 11+ years in tech (Full Stack → Team Lead → R&D Leader)",
   ABOUT_PASSION: '   • Passionate about AI-driven innovation',
   ABOUT_CULTURE: '   • Building high-performance teams with strong culture',
   
@@ -140,7 +140,7 @@ export const CONSOLE_SDK = {
   GREETING_HINT_SUFFIX: ' to explore — or just expand the object below.',
 
   // Returned when the object is coerced to a string (e.g. `${victoria}`).
-  SIGNATURE: 'Victoria Kirichenko — R&D Team Leader. I build systems that scale, and teams that want to.',
+  SIGNATURE: 'Victoria Kirichenko — R&D Leader. I build systems that scale, and teams that want to.',
 
   HELP_TITLE: '🗂  victoria.* — call any of these:',
   COMMANDS: [
@@ -200,21 +200,22 @@ export const CONSOLE_SDK = {
 
   IMPACT_TITLE: '📈 Outcomes, not adjectives',
   IMPACT: [
-    { area: 'AI workflow automation', where: 'Swish.ai', outcome: '−60% manual tasks' },
-    { area: 'Team leadership', where: 'Swish.ai · Perion', outcome: 'Led 5 eng + QA via Scrum' },
-    { area: 'Ad-tech platform', where: 'Perion Network', outcome: 'Millions of requests / day' },
-    { area: 'Trajectory', where: '10+ years', outcome: 'Full-Stack → Team Lead → R&D Leader' },
+    { area: 'AI workflow automation', where: 'Swish.ai', outcome: '−60% manual tasks automated' },
+    { area: 'Team leadership', where: 'Swish.ai · Perion', outcome: '5+ QA engineers led — offshore & onsite' },
+    { area: 'Ad-tech platform', where: 'Perion Network', outcome: 'Millions of ad requests & users / day' },
+    { area: 'Trajectory', where: '11+ years', outcome: 'Full-Stack → Team Lead → R&D Leader' },
   ],
   IMPACT_RETURN: "Numbers I'm happy to walk you through.",
 
   EXPERIENCE_TITLE: '🗓  Experience — the timeline',
   EXPERIENCE: [
-    { role: 'R&D Team Leader', company: 'Zencity', period: '2026 → now', focus: 'Just getting started — magic in progress' },
-    { role: 'R&D Team Leader', company: 'Swish.ai', period: '2024 → 2025', focus: 'AI-driven IT workflow optimization' },
-    { role: 'R&D Team Leader', company: 'Perion Network', period: '2021 → 2024', focus: 'Led 5; microservices + MongoDB' },
-    { role: 'Full-Stack Developer', company: 'Perion Network', period: '2018 → 2021', focus: 'React · Next.js · Node' },
-    { role: 'Full-Stack Developer', company: 'Mind Connect', period: '2016 → 2018', focus: 'Call-center platform' },
-    { role: 'Full-Stack Developer', company: 'PowerTech', period: '2015 → 2016', focus: '.NET · MSSQL' },
+    { role: 'R&D Team Leader', company: 'Zencity', period: 'Mar 2026 → now', focus: 'Just getting started — magic in progress' },
+    { role: 'R&D Team Leader', company: 'Swish.ai', period: 'Apr 2024 → Oct 2025', focus: 'AI-driven IT workflow optimization' },
+    { role: 'R&D Team Leader', company: 'Perion Network', period: 'Apr 2021 → Apr 2024', focus: 'Led 5; microservices + MongoDB' },
+    { role: 'Full-Stack Developer', company: 'Perion Network', period: 'Jun 2018 → Apr 2021', focus: 'React · Next.js · Node' },
+    { role: 'Full-Stack Developer', company: 'Mind Connect', period: 'Mar 2016 → Apr 2018', focus: 'Call-center platform' },
+    { role: 'Full-Stack Developer', company: 'PowerTech', period: 'Feb 2015 → Mar 2016', focus: '.NET · MSSQL' },
+    { role: 'Full-Stack Developer', company: 'Early Career', period: 'Dec 2012 → Jan 2015', focus: 'Foundations across the stack' },
     { role: 'MSc, Computer Science', company: 'Penza State University', period: '2007 → 2012', focus: 'Foundations' },
   ],
 

--- a/client/src/pages/home.module.css
+++ b/client/src/pages/home.module.css
@@ -1504,16 +1504,6 @@
   text-align: center;
 }
 
-.footer__name {
-  font-size: var(--font-size-2xl);
-  font-weight: var(--font-weight-bold);
-  background: var(--gradient-primary);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  margin-bottom: var(--spacing-4);
-}
-
 .footer__tagline {
   color: var(--color-neutral-400);
   margin-bottom: var(--spacing-6);
@@ -1526,8 +1516,6 @@
   font-style: italic;
   font-size: var(--font-size-lg);
   line-height: 1.7;
-  border-top: 1px solid var(--color-neutral-800);
-  padding-top: var(--spacing-8);
 }
 
 .footer__copyright {

--- a/client/src/pages/home.module.css
+++ b/client/src/pages/home.module.css
@@ -262,16 +262,29 @@
   font-weight: var(--font-weight-regular);
 }
 
+/* Editorial kicker (matches the About section's kicker + gradient rails) —
+   a short cream rule + uppercase, tracked label. No pill: the rounded chip
+   clashed with the brutalist, sharp-edged system. */
 .hero__roleChip {
-  padding: var(--spacing-1) var(--spacing-3);
-  background: hsla(42, 30%, 88%, 0.08);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: 0;
+  background: none;
   border: none;
-  color: var(--color-neutral-300);
-  border-radius: var(--radius-full);
+  color: var(--color-primary-400);
   font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-medium);
-  letter-spacing: 0.08em;
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
   white-space: nowrap;
+}
+
+.hero__roleChip::before {
+  content: '';
+  width: var(--spacing-6);
+  height: 2px;
+  background: var(--gradient-primary);
 }
 
 .hero__tagline {

--- a/client/src/pages/home.module.css
+++ b/client/src/pages/home.module.css
@@ -1519,31 +1519,6 @@
   margin-bottom: var(--spacing-6);
 }
 
-.footer__social {
-  display: flex;
-  justify-content: center;
-  gap: var(--spacing-6);
-  margin-bottom: var(--spacing-8);
-}
-
-.footer__socialLink {
-  color: var(--color-neutral-400);
-  transition: color 0.2s ease-in-out,
-              transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-  will-change: transform;
-  display: inline-block;
-}
-
-.footer__socialLink:hover {
-  color: var(--color-primary-400);
-  transform: scale(1.2);
-}
-
-.footer__socialIcon {
-  width: 1.5rem;
-  height: 1.5rem;
-}
-
 .footer__quote {
   max-width: 38rem;
   margin: 0 auto;

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -814,24 +814,6 @@ export default function Home() {
         <div className={styles.footer__container}>
           <div className={styles.footer__content}>
             <div className={styles.footer__name}>{PERSONAL_INFO.INITIALS}</div>
-            <div className={styles.footer__social}>
-              <motion.a
-                href={`mailto:${PERSONAL_INFO.EMAIL}`}
-                className={styles.footer__socialLink}
-                whileHover={{ scale: TRANSFORM.HOVER_SCALE_LARGE }}
-              >
-                <Mail className={styles.footer__socialIcon} />
-              </motion.a>
-              <motion.a
-                href={PERSONAL_INFO.LINKEDIN_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={styles.footer__socialLink}
-                whileHover={{ scale: TRANSFORM.HOVER_SCALE_LARGE }}
-              >
-                <ExternalLink className={styles.footer__socialIcon} />
-              </motion.a>
-            </div>
             <blockquote className={styles.footer__quote}>{TAGLINES.FOOTER_QUOTE}</blockquote>
             <p className={styles.footer__copyright}>{COPYRIGHT.TEXT}</p>
           </div>

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -418,7 +418,7 @@ export default function Home() {
                     </div>
                     <h4 className={styles.experience__company}>Swish.ai • Tel Aviv, Israel</h4>
                     <p className={styles.experience__description}>
-                      Leading IT workflow optimization with a people-first approach. Driving innovation through AI-driven solutions while fostering collaborative, growth-focused culture using Scrum methodology.
+                      Led IT workflow optimization with a people-first approach. Drove innovation through AI-driven solutions while fostering a collaborative, growth-focused culture using Scrum methodology.
                     </p>
                     <div className={styles.experience__tags}>
                       {['AI Automation', 'Team Leadership', 'Scrum', 'Workflow Optimization'].map((skill) => (

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -813,7 +813,6 @@ export default function Home() {
       <footer className={styles.footer}>
         <div className={styles.footer__container}>
           <div className={styles.footer__content}>
-            <div className={styles.footer__name}>{PERSONAL_INFO.INITIALS}</div>
             <blockquote className={styles.footer__quote}>{TAGLINES.FOOTER_QUOTE}</blockquote>
             <p className={styles.footer__copyright}>{COPYRIGHT.TEXT}</p>
           </div>

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -386,7 +386,7 @@ export default function Home() {
             <div className={styles.experience__timeline}>
               <div className={styles.experience__timelineLine}></div>
 
-              {/* Current Position - Swish.ai */}
+              {/* Current Position - Zencity */}
               <ScrollReveal delay={ANIMATION_DELAY.MEDIUM}>
                 <div className={styles.experience__item}>
                   <motion.div
@@ -397,7 +397,24 @@ export default function Home() {
                   <div className={`${styles.experience__card} ${styles.card} ${styles['card--hover']}`}>
                     <div className={styles.experience__header}>
                       <h3 className={styles.experience__title}>R&D Team Leader</h3>
-                      <span className={styles.experience__period}>April 2024 - Present</span>
+                      <span className={styles.experience__period}>March 2026 - Present</span>
+                    </div>
+                    <h4 className={styles.experience__company}>Zencity • Tel Aviv, Israel</h4>
+                    <p className={styles.experience__description}>
+                      Just getting started — magic in progress. This chapter will be updated soon.
+                    </p>
+                  </div>
+                </div>
+              </ScrollReveal>
+
+              {/* Swish.ai */}
+              <ScrollReveal delay={ANIMATION_DELAY.LONG}>
+                <div className={styles.experience__item}>
+                  <div className={styles.experience__dot} />
+                  <div className={`${styles.experience__card} ${styles.card} ${styles['card--hover']}`}>
+                    <div className={styles.experience__header}>
+                      <h3 className={styles.experience__title}>R&D Team Leader</h3>
+                      <span className={styles.experience__period}>April 2024 - October 2025</span>
                     </div>
                     <h4 className={styles.experience__company}>Swish.ai • Tel Aviv, Israel</h4>
                     <p className={styles.experience__description}>


### PR DESCRIPTION
The footer repeated the email + LinkedIn icons that already appear in the Contact section directly above it. Drop the redundant social row (and its dead CSS); keep the monogram, closing quote, and copyright as a clean sign-off.