### PR TITLE
style: use array-index notation for leadership principle labels

### DIFF
--- a/client/src/pages/home.module.css
+++ b/client/src/pages/home.module.css
@@ -1353,6 +1353,10 @@
   margin-bottom: var(--spacing-3);
 }
 
+.philosophy__principleNumberName {
+  color: var(--color-neutral-600);
+}
+
 .philosophy__principleTitle {
   font-family: var(--font-family-mono);
   font-size: var(--font-size-base);

--- a/client/src/pages/home.module.css
+++ b/client/src/pages/home.module.css
@@ -1349,12 +1349,14 @@
   display: block;
   font-family: var(--font-family-mono);
   font-size: var(--font-size-sm);
-  color: var(--color-primary-400);
+  color: var(--color-foreground);
+  letter-spacing: 0.1em;
   margin-bottom: var(--spacing-3);
 }
 
-.philosophy__principleNumberName {
-  color: var(--color-neutral-600);
+.philosophy__principleNumberBracket {
+  color: hsl(42, 17%, 56%);
+  margin: 0 0.35em;
 }
 
 .philosophy__principleTitle {

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -487,7 +487,7 @@ export default function Home() {
                       <ScrollReveal key={item.title} delay={ANIMATION_DELAY.LONG + index * ANIMATION_DELAY.MEDIUM}>
                         <div className={styles.philosophy__principle}>
                           <span className={styles.philosophy__principleNumber}>
-                            {String(index + 1).padStart(2, '0')}
+                            <span className={styles.philosophy__principleNumberName}>values</span>[{index}]
                           </span>
                           <h4 className={styles.philosophy__principleTitle}>{item.title}</h4>
                           <p className={styles.philosophy__principleDescription}>{item.description}</p>

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -487,7 +487,9 @@ export default function Home() {
                       <ScrollReveal key={item.title} delay={ANIMATION_DELAY.LONG + index * ANIMATION_DELAY.MEDIUM}>
                         <div className={styles.philosophy__principle}>
                           <span className={styles.philosophy__principleNumber}>
-                            <span className={styles.philosophy__principleNumberName}>values</span>[{index}]
+                            <span className={styles.philosophy__principleNumberBracket}>[</span>
+                            {index}
+                            <span className={styles.philosophy__principleNumberBracket}>]</span>
                           </span>
                           <h4 className={styles.philosophy__principleTitle}>{item.title}</h4>
                           <p className={styles.philosophy__principleDescription}>{item.description}</p>


### PR DESCRIPTION
Replace 01/02/03 numbering with zero-indexed values[N] array access, muting the "values" prefix while keeping the index in the accent color.