### PR TITLE
feat: add victoria.maze() console easter egg + code-native greeting

### DIFF
--- a/client/src/constants/strings.ts
+++ b/client/src/constants/strings.ts
@@ -135,12 +135,16 @@ export const CONSOLE_MESSAGES = {
 // Console SDK - the interactive `window.victoria` developer experience.
 // Content lives here (the repo centralizes strings); rendering lives in lib/console-signature.ts.
 export const CONSOLE_SDK = {
-  GREETING_TITLE: '👋 You found the console - good instinct.',
-  GREETING_BODY:
-    "This is `victoria`: a tiny SDK about how I build and lead. Same thing I do in real systems - make the parts that matter easy to find.",
-  GREETING_HINT_PREFIX: 'Run ',
-  GREETING_HINT_CMD: 'victoria.help()',
-  GREETING_HINT_SUFFIX: ' to explore - or just expand the object below.',
+  // Greeting reads as a code snippet: a comment, a `const` declaration, then two
+  // command hints tagged like inline comments. Understated, dev-native.
+  GREETING_COMMENT: '// most of the story is on the page. the rest is here.',
+  GREETING_CODE_KEYWORD: 'const',
+  GREETING_CODE_NAME: 'victoria',
+  GREETING_CODE_REST: ' = sdk({ build, lead })',
+  GREETING_HELP_CMD: 'victoria.help()',
+  GREETING_HELP_TAG: '→ explore',
+  GREETING_MAZE_CMD: 'victoria.maze()',
+  GREETING_MAZE_TAG: "→ there's always a way through",
 
   // Returned when the object is coerced to a string (e.g. `${victoria}`).
   SIGNATURE: 'Victoria Kirichenko - R&D Leader. I build systems that scale, and teams that want to.',
@@ -153,6 +157,7 @@ export const CONSOLE_SDK = {
     { command: 'victoria.decisions()', what: 'how I make the hard calls' },
     { command: 'victoria.principles()', what: 'what I lead by' },
     { command: 'victoria.story()', what: 'how I actually got here' },
+    { command: 'victoria.maze()', what: 'a tangle, solved - the way through' },
     { command: 'victoria.skills()', what: 'the tech arsenal' },
     { command: 'victoria.hire()', what: 'why we should talk' },
     { command: 'victoria.contact()', what: 'reach me directly' },
@@ -244,6 +249,10 @@ export const CONSOLE_SDK = {
 
   CONTACT_TITLE: '📬 Reach me directly',
   CONTACT_RETURN: 'I read every message. The interesting ones I answer fast.',
+
+  MAZE_TITLE: '🧩 A tangle - and the way through',
+  MAZE_CAPTION: "WHEN THERE'S A WILL, THERE'S A WAY.",
+  MAZE_RETURN: 'Every tangle has a path - my job is finding it.',
 } as const;
 
 // ASCII Art

--- a/client/src/lib/console-signature.ts
+++ b/client/src/lib/console-signature.ts
@@ -21,10 +21,134 @@ const STYLE = {
   body: `color:${CONSOLE_PALETTE.BODY};font-size:${CONSOLE_FONT_SIZE.SMALL};`,
   accent: `color:${CONSOLE_PALETTE.ACCENT};`,
   command: `color:${CONSOLE_PALETTE.ACCENT};font-weight:bold;`,
+  comment: `color:${CONSOLE_PALETTE.DIM};font-style:italic;font-size:${CONSOLE_FONT_SIZE.SMALL};`,
+  name: `color:${CONSOLE_PALETTE.TITLE};font-weight:bold;`,
 } as const;
 
 function line(text: string, style: string): void {
   console.log(`%c${text}`, style);
+}
+
+// --- victoria.maze(): a fresh, always-solvable maze with its one path traced ---
+// Same idea as the site's "tangle to clarity" motif: there's always a way through.
+const MAZE_COLS = 11;
+const MAZE_ROWS = 9;
+
+// Box-drawing glyph for a wall cell, keyed by which of its up/down/left/right
+// neighbours are also walls (1 = connected). Correct junctions = no floating stubs.
+const MAZE_BOX: Record<string, string> = {
+  '0000': ' ', '0001': '╶', '0010': '╴', '0011': '─',
+  '0100': '╷', '0101': '┌', '0110': '┐', '0111': '┬',
+  '1000': '╵', '1001': '└', '1010': '┘', '1011': '┴',
+  '1100': '│', '1101': '├', '1110': '┤', '1111': '┼',
+};
+
+/**
+ * Generate a random maze (recursive backtracker) on a (2·cols+1)×(2·rows+1) grid,
+ * solve it entrance→exit with BFS, and return thin-line rows. Walls become box
+ * glyphs, the solution is a "·" trail, and the exit is marked with "→".
+ */
+function generateMaze(cols: number, rows: number): string[] {
+  const W = 2 * cols + 1;
+  const H = 2 * rows + 1;
+  const g: string[][] = Array.from({ length: H }, () => Array<string>(W).fill('#'));
+  const visited: boolean[][] = Array.from({ length: rows }, () => Array<boolean>(cols).fill(false));
+
+  const carve = (cx: number, cy: number): void => {
+    visited[cy][cx] = true;
+    g[2 * cy + 1][2 * cx + 1] = ' ';
+    const dirs = [[0, -1], [1, 0], [0, 1], [-1, 0]];
+    for (let i = dirs.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [dirs[i], dirs[j]] = [dirs[j], dirs[i]];
+    }
+    for (const [dx, dy] of dirs) {
+      const nx = cx + dx;
+      const ny = cy + dy;
+      if (nx < 0 || ny < 0 || nx >= cols || ny >= rows || visited[ny][nx]) continue;
+      g[2 * cy + 1 + dy][2 * cx + 1 + dx] = ' ';
+      carve(nx, ny);
+    }
+  };
+  carve(0, 0);
+
+  g[1][0] = ' '; // entrance: left edge, top row
+  g[H - 2][W - 1] = ' '; // exit: right edge, bottom row
+
+  // BFS for the shortest entrance→exit path (a single, non-branching trail).
+  const key = (r: number, c: number) => r * W + c;
+  const prev = new Map<number, number | null>();
+  const queue: Array<[number, number]> = [[1, 0]];
+  prev.set(key(1, 0), null);
+  const end = key(H - 2, W - 1);
+  while (queue.length) {
+    const [r, c] = queue.shift() as [number, number];
+    if (key(r, c) === end) break;
+    for (const [dr, dc] of [[0, 1], [1, 0], [0, -1], [-1, 0]]) {
+      const nr = r + dr;
+      const nc = c + dc;
+      if (nr < 0 || nc < 0 || nr >= H || nc >= W) continue;
+      if (g[nr][nc] === '#' || prev.has(key(nr, nc))) continue;
+      prev.set(key(nr, nc), key(r, c));
+      queue.push([nr, nc]);
+    }
+  }
+  for (let cur: number | null | undefined = end; cur != null; cur = prev.get(cur)) {
+    const r = Math.floor(cur / W);
+    const c = cur % W;
+    if (g[r][c] === ' ') g[r][c] = '·';
+  }
+
+  const isWall = (r: number, c: number) => r >= 0 && c >= 0 && r < H && c < W && g[r][c] === '#';
+  const out: string[] = [];
+  for (let r = 0; r < H; r++) {
+    let row = '';
+    for (let c = 0; c < W; c++) {
+      const ch = g[r][c];
+      if (ch === '#') {
+        const u = isWall(r - 1, c) ? 1 : 0;
+        const d = isWall(r + 1, c) ? 1 : 0;
+        const l = isWall(r, c - 1) ? 1 : 0;
+        const ri = isWall(r, c + 1) ? 1 : 0;
+        row += MAZE_BOX[`${u}${d}${l}${ri}`];
+      } else {
+        row += ch;
+      }
+    }
+    out.push(row);
+  }
+  out[H - 2] += '→'; // point the way out
+  return out;
+}
+
+/** Print the maze in two tones: dim walls, champagne solution path. */
+function drawMaze(): void {
+  const rows = generateMaze(MAZE_COLS, MAZE_ROWS);
+  const wallStyle = `color:${CONSOLE_PALETTE.DIM};`;
+  const pathStyle = `color:${CONSOLE_PALETTE.ACCENT};font-weight:bold;`;
+  const isPath = (ch: string) => ch === '·' || ch === '→';
+
+  let fmt = '';
+  const styles: string[] = [];
+  rows.forEach((row, i) => {
+    let run = '';
+    let runIsPath = false;
+    const flush = () => {
+      if (!run) return;
+      fmt += `%c${run}`;
+      styles.push(runIsPath ? pathStyle : wallStyle);
+      run = '';
+    };
+    for (const ch of row) {
+      const p = isPath(ch);
+      if (run && p !== runIsPath) flush();
+      runIsPath = p;
+      run += ch;
+    }
+    flush();
+    if (i < rows.length - 1) fmt += '\n';
+  });
+  console.log(fmt, ...styles);
 }
 
 function block(title: string, items: readonly string[]): void {
@@ -33,13 +157,22 @@ function block(title: string, items: readonly string[]): void {
 }
 
 function greet(): void {
-  line(CONSOLE_SDK.GREETING_TITLE, STYLE.title);
-  line(CONSOLE_SDK.GREETING_BODY, STYLE.body);
+  line(CONSOLE_SDK.GREETING_COMMENT, STYLE.comment);
   console.log(
-    `%c${CONSOLE_SDK.GREETING_HINT_PREFIX}%c${CONSOLE_SDK.GREETING_HINT_CMD}%c${CONSOLE_SDK.GREETING_HINT_SUFFIX}`,
+    `%c${CONSOLE_SDK.GREETING_CODE_KEYWORD} %c${CONSOLE_SDK.GREETING_CODE_NAME}%c${CONSOLE_SDK.GREETING_CODE_REST}`,
     STYLE.accent,
+    STYLE.name,
+    STYLE.body,
+  );
+  console.log(
+    `\n%c${CONSOLE_SDK.GREETING_HELP_CMD}%c  ${CONSOLE_SDK.GREETING_HELP_TAG}`,
     STYLE.command,
-    STYLE.accent,
+    STYLE.comment,
+  );
+  console.log(
+    `%c${CONSOLE_SDK.GREETING_MAZE_CMD}%c  ${CONSOLE_SDK.GREETING_MAZE_TAG}`,
+    STYLE.command,
+    STYLE.comment,
   );
 }
 
@@ -85,6 +218,12 @@ function buildApi() {
     story() {
       block(CONSOLE_SDK.STORY_TITLE, CONSOLE_SDK.STORY);
       return CONSOLE_SDK.STORY_RETURN;
+    },
+    maze() {
+      line(`\n${CONSOLE_SDK.MAZE_TITLE}`, STYLE.heading);
+      drawMaze();
+      line(`\n${CONSOLE_SDK.MAZE_CAPTION}`, STYLE.subheading);
+      return CONSOLE_SDK.MAZE_RETURN;
     },
     skills() {
       line(CONSOLE_MESSAGES.SKILLS_TITLE, STYLE.heading);


### PR DESCRIPTION
Replace the eager four-line console intro with a restrained, code-native greeting rendered as a `const victoria = sdk({ build, lead })` snippet.

Add victoria.maze(): generates a fresh, always-solvable maze (recursive backtracker + BFS-traced solution) rendered thin-line with a two-tone path, echoing the site's tangle-to-clarity motif and signing off with "WHEN THERE'S A WILL, THERE'S A WAY."