### PR TITLE
refactor: drop victoria.maze() heading, let the maze speak

### DIFF
--- a/client/src/constants/strings.ts
+++ b/client/src/constants/strings.ts
@@ -250,7 +250,6 @@ export const CONSOLE_SDK = {
   CONTACT_TITLE: '📬 Reach me directly',
   CONTACT_RETURN: 'I read every message. The interesting ones I answer fast.',
 
-  MAZE_TITLE: '🧩 A tangle - and the way through',
   MAZE_CAPTION: "WHEN THERE'S A WILL, THERE'S A WAY.",
   MAZE_RETURN: 'Every tangle has a path - my job is finding it.',
 } as const;

--- a/client/src/lib/console-signature.ts
+++ b/client/src/lib/console-signature.ts
@@ -220,7 +220,6 @@ function buildApi() {
       return CONSOLE_SDK.STORY_RETURN;
     },
     maze() {
-      line(`\n${CONSOLE_SDK.MAZE_TITLE}`, STYLE.heading);
       drawMaze();
       line(`\n${CONSOLE_SDK.MAZE_CAPTION}`, STYLE.subheading);
       return CONSOLE_SDK.MAZE_RETURN;


### PR DESCRIPTION
Remove the "A tangle - and the way through" title line (and its unused MAZE_TITLE string) so the command goes straight to the maze + caption.