### PR TITLE
refactor: green command tables, warm punchlines, drop redundant titles

### DIFF
--- a/client/src/constants/colors.ts
+++ b/client/src/constants/colors.ts
@@ -11,7 +11,8 @@ export const CONSOLE_PALETTE = {
   HEADING: 'hsl(42, 40%, 76%)', // champagne - section headers
   SUBHEADING: 'hsl(40, 22%, 84%)', // soft cream - sub-headers
   BODY: 'hsl(38, 11%, 66%)', // warm gray - body copy
-  ACCENT: 'hsl(44, 46%, 71%)', // champagne - the single functional pop (commands, links)
+  ACCENT: 'hsl(44, 46%, 71%)', // champagne - links, punchlines, hints
+  COMMAND: 'hsl(122, 70%, 55%)', // phosphor green - the "code/command" token color
   DIM: 'hsl(34, 8%, 50%)', // muted warm gray - secondary detail
 } as const;
 

--- a/client/src/constants/strings.ts
+++ b/client/src/constants/strings.ts
@@ -113,7 +113,6 @@ export const CONSOLE_MESSAGES = {
   DIVIDER: '─────────────────────────────────────────────────────────────',
   
   // Window functions
-  SKILLS_TITLE: "🚀 Victoria's Tech Arsenal:",
   SKILLS_LANGUAGES: '   Languages: TypeScript, Python, JavaScript, .NET',
   SKILLS_FRONTEND: '   Frontend: React, HTML5, CSS3',
   SKILLS_BACKEND: '   Backend: Node.js, Express, .NET, PHP',
@@ -149,10 +148,9 @@ export const CONSOLE_SDK = {
   // Returned when the object is coerced to a string (e.g. `${victoria}`).
   SIGNATURE: 'Victoria Kirichenko - R&D Leader. I build systems that scale, and teams that want to.',
 
-  HELP_TITLE: '🗂  victoria.* - call any of these:',
   COMMANDS: [
     { command: 'victoria.readme()', what: 'how I work, what I value, how to get my best' },
-    { command: 'victoria.experience', what: 'the timeline, as data you can expand' },
+    { command: 'victoria.experience', what: 'the timeline, role by role' },
     { command: 'victoria.impact()', what: 'outcomes, not adjectives' },
     { command: 'victoria.decisions()', what: 'how I make the hard calls' },
     { command: 'victoria.principles()', what: 'what I lead by' },
@@ -164,7 +162,6 @@ export const CONSOLE_SDK = {
   ],
   HELP_RETURN: '↑ call any command, e.g. victoria.readme()',
 
-  README_TITLE: '📄 README - working with Victoria',
   README_SECTIONS: [
     {
       h: 'What I optimize for',
@@ -197,7 +194,6 @@ export const CONSOLE_SDK = {
   ],
   README_RETURN: "That's the contract. Reciprocity is the point - send me yours.",
 
-  DECISIONS_TITLE: '🧭 How I make the hard calls',
   DECISIONS: [
     'One-way doors vs. reversible: I move fast on what we can undo, and slow down only for what we genuinely can’t.',
     'Clarity beats cleverness: the solution the whole team understands usually beats the elegant one only I do.',
@@ -206,7 +202,6 @@ export const CONSOLE_SDK = {
   ],
   DECISIONS_RETURN: 'Judgment over job titles.',
 
-  IMPACT_TITLE: '📈 Outcomes, not adjectives',
   IMPACT: [
     { area: 'AI workflow automation', where: 'Swish.ai', outcome: '−60% manual tasks automated' },
     { area: 'Team leadership', where: 'Swish.ai · Perion', outcome: '5+ QA engineers led - offshore & onsite' },
@@ -215,7 +210,6 @@ export const CONSOLE_SDK = {
   ],
   IMPACT_RETURN: "Numbers I'm happy to walk you through.",
 
-  EXPERIENCE_TITLE: '🗓  Experience - the timeline',
   EXPERIENCE: [
     { role: 'R&D Team Leader', company: 'Zencity', period: 'Mar 2026 → now', focus: 'Just getting started - magic in progress' },
     { role: 'R&D Team Leader', company: 'Swish.ai', period: 'Apr 2024 → Oct 2025', focus: 'AI-driven IT workflow optimization' },
@@ -226,8 +220,8 @@ export const CONSOLE_SDK = {
     { role: 'Full-Stack Developer', company: 'Early Career', period: 'Dec 2012 → Jan 2015', focus: 'Foundations across the stack' },
     { role: 'MSc, Computer Science', company: 'Penza State University', period: '2007 → 2012', focus: 'Foundations' },
   ],
+  EXPERIENCE_RETURN: 'Eleven years, one direction: up and toward the hard problems.',
 
-  STORY_TITLE: '🌍 How I actually got here',
   STORY: [
     'I started in Penza, Russia, and moved to a new country alone - no network, no shortcuts.',
     'I built my career from scratch, in a second language, one hard problem at a time.',
@@ -236,10 +230,8 @@ export const CONSOLE_SDK = {
   ],
   STORY_RETURN: 'Not despite the struggle - because of it.',
 
-  PRINCIPLES_TITLE: '⚖️  What I lead by',
   PRINCIPLES_RETURN: 'Clarity. Safety. Accountability - in that order.',
 
-  HIRE_TITLE: '🤝 Why we should talk',
   HIRE: [
     'Most companies hide a recruiting pitch in their console. Plot twist: here, I’m the one worth recruiting.',
     'I turn ambiguous R&D into shipped product, and I raise the bar of everyone around me.',
@@ -247,7 +239,6 @@ export const CONSOLE_SDK = {
   ],
   HIRE_HINT: '→ victoria.contact() to start the conversation',
 
-  CONTACT_TITLE: '📬 Reach me directly',
   CONTACT_RETURN: 'I read every message. The interesting ones I answer fast.',
 
   MAZE_CAPTION: "WHEN THERE'S A WILL, THERE'S A WAY.",

--- a/client/src/lib/console-signature.ts
+++ b/client/src/lib/console-signature.ts
@@ -20,13 +20,47 @@ const STYLE = {
   subheading: `color:${CONSOLE_PALETTE.SUBHEADING};font-weight:bold;`,
   body: `color:${CONSOLE_PALETTE.BODY};font-size:${CONSOLE_FONT_SIZE.SMALL};`,
   accent: `color:${CONSOLE_PALETTE.ACCENT};`,
-  command: `color:${CONSOLE_PALETTE.ACCENT};font-weight:bold;`,
+  command: `color:${CONSOLE_PALETTE.COMMAND};font-weight:bold;`,
   comment: `color:${CONSOLE_PALETTE.DIM};font-style:italic;font-size:${CONSOLE_FONT_SIZE.SMALL};`,
   name: `color:${CONSOLE_PALETTE.TITLE};font-weight:bold;`,
+  tableHead: `color:${CONSOLE_PALETTE.DIM};font-size:${CONSOLE_FONT_SIZE.SMALL};`,
 } as const;
 
 function line(text: string, style: string): void {
   console.log(`%c${text}`, style);
+}
+
+// Log a command's closing punchline in the phosphor accent color and return
+// undefined - so the line reads green rather than the browser's own (blue)
+// color for an echoed return value.
+function close(text: string): void {
+  line(`\n${text}`, STYLE.accent);
+}
+
+// A console.table replacement we can actually color: console.table cell text is
+// drawn by DevTools (always blue) and can't be styled, so we render aligned,
+// monospace columns via %c instead - command column in phosphor green, the rest warm.
+type TableColumn = { key: string; header: string; style: string };
+function styledTable(rows: readonly Record<string, unknown>[], columns: TableColumn[]): void {
+  const cell = (row: Record<string, unknown>, key: string) => String(row[key] ?? '');
+  const widths = columns.map((c) =>
+    Math.max(c.header.length, ...rows.map((r) => cell(r, c.key).length)),
+  );
+  const styles: string[] = [];
+  let fmt = '';
+  const pushRow = (values: string[], rowStyles: string[]) => {
+    values.forEach((v, ci) => {
+      const last = ci === columns.length - 1;
+      fmt += `%c${last ? v : v.padEnd(widths[ci] + 2)}`;
+      styles.push(rowStyles[ci]);
+    });
+  };
+  pushRow(columns.map((c) => c.header), columns.map(() => STYLE.tableHead));
+  rows.forEach((r) => {
+    fmt += '\n';
+    pushRow(columns.map((c) => cell(r, c.key)), columns.map((c) => c.style));
+  });
+  console.log(fmt, ...styles);
 }
 
 // --- victoria.maze(): a fresh, always-solvable maze with its one path traced ---
@@ -151,8 +185,7 @@ function drawMaze(): void {
   console.log(fmt, ...styles);
 }
 
-function block(title: string, items: readonly string[]): void {
-  line(`\n${title}`, STYLE.heading);
+function bullets(items: readonly string[]): void {
   items.forEach((item) => line(`  • ${item}`, STYLE.body));
 }
 
@@ -179,53 +212,59 @@ function greet(): void {
 function buildApi() {
   const api = {
     help() {
-      line(CONSOLE_SDK.HELP_TITLE, STYLE.heading);
-      console.table(CONSOLE_SDK.COMMANDS);
-      return CONSOLE_SDK.HELP_RETURN;
+      styledTable(CONSOLE_SDK.COMMANDS, [
+        { key: 'command', header: 'command', style: STYLE.command },
+        { key: 'what', header: 'what', style: STYLE.body },
+      ]);
+      close(CONSOLE_SDK.HELP_RETURN);
     },
     readme() {
-      line(CONSOLE_SDK.README_TITLE, STYLE.heading);
       CONSOLE_SDK.README_SECTIONS.forEach((section) => {
         line(`\n${section.h}`, STYLE.subheading);
         line(`  ${section.body}`, STYLE.body);
       });
-      return CONSOLE_SDK.README_RETURN;
+      close(CONSOLE_SDK.README_RETURN);
     },
-    // A getter, so `victoria.experience` (no parens) prints the table *and* hands back
-    // the array for the reader to expand and interrogate.
+    // A getter, so `victoria.experience` (no parens) prints the timeline on access.
     get experience() {
-      line(`\n${CONSOLE_SDK.EXPERIENCE_TITLE}`, STYLE.heading);
-      console.table(CONSOLE_SDK.EXPERIENCE);
-      return CONSOLE_SDK.EXPERIENCE;
+      styledTable(CONSOLE_SDK.EXPERIENCE, [
+        { key: 'role', header: 'role', style: STYLE.command },
+        { key: 'company', header: 'company', style: STYLE.subheading },
+        { key: 'period', header: 'period', style: STYLE.body },
+        { key: 'focus', header: 'focus', style: STYLE.body },
+      ]);
+      close(CONSOLE_SDK.EXPERIENCE_RETURN);
+      return undefined;
     },
     impact() {
-      line(CONSOLE_SDK.IMPACT_TITLE, STYLE.heading);
-      console.table(CONSOLE_SDK.IMPACT);
-      return CONSOLE_SDK.IMPACT_RETURN;
+      styledTable(CONSOLE_SDK.IMPACT, [
+        { key: 'area', header: 'area', style: STYLE.command },
+        { key: 'where', header: 'where', style: STYLE.subheading },
+        { key: 'outcome', header: 'outcome', style: STYLE.accent },
+      ]);
+      close(CONSOLE_SDK.IMPACT_RETURN);
     },
     decisions() {
-      block(CONSOLE_SDK.DECISIONS_TITLE, CONSOLE_SDK.DECISIONS);
-      return CONSOLE_SDK.DECISIONS_RETURN;
+      bullets(CONSOLE_SDK.DECISIONS);
+      close(CONSOLE_SDK.DECISIONS_RETURN);
     },
     principles() {
-      line(CONSOLE_SDK.PRINCIPLES_TITLE, STYLE.heading);
       LEADERSHIP_PRINCIPLES.forEach((principle) => {
         line(`\n${principle.title}`, STYLE.subheading);
         line(`  ${principle.description}`, STYLE.body);
       });
-      return CONSOLE_SDK.PRINCIPLES_RETURN;
+      close(CONSOLE_SDK.PRINCIPLES_RETURN);
     },
     story() {
-      block(CONSOLE_SDK.STORY_TITLE, CONSOLE_SDK.STORY);
-      return CONSOLE_SDK.STORY_RETURN;
+      bullets(CONSOLE_SDK.STORY);
+      close(CONSOLE_SDK.STORY_RETURN);
     },
     maze() {
       drawMaze();
       line(`\n${CONSOLE_SDK.MAZE_CAPTION}`, STYLE.subheading);
-      return CONSOLE_SDK.MAZE_RETURN;
+      close(CONSOLE_SDK.MAZE_RETURN);
     },
     skills() {
-      line(CONSOLE_MESSAGES.SKILLS_TITLE, STYLE.heading);
       [
         CONSOLE_MESSAGES.SKILLS_LANGUAGES,
         CONSOLE_MESSAGES.SKILLS_FRONTEND,
@@ -233,19 +272,18 @@ function buildApi() {
         CONSOLE_MESSAGES.SKILLS_CLOUD,
         CONSOLE_MESSAGES.SKILLS_LEADERSHIP,
       ].forEach((skill) => line(skill, STYLE.body));
-      return CONSOLE_MESSAGES.SKILLS_RETURN;
+      close(CONSOLE_MESSAGES.SKILLS_RETURN);
     },
     hire() {
-      block(CONSOLE_SDK.HIRE_TITLE, CONSOLE_SDK.HIRE);
+      bullets(CONSOLE_SDK.HIRE);
       line(`\n${CONSOLE_SDK.HIRE_HINT}`, STYLE.accent);
-      return TAGLINES.PRIMARY;
+      close(TAGLINES.PRIMARY);
     },
     contact() {
-      line(CONSOLE_SDK.CONTACT_TITLE, STYLE.heading);
       line(`  Email     ${PERSONAL_INFO.EMAIL}`, STYLE.accent);
       line(`  LinkedIn  ${PERSONAL_INFO.LINKEDIN_URL}`, STYLE.accent);
       line(`  Location  ${PERSONAL_INFO.LOCATION}`, STYLE.body);
-      return CONSOLE_SDK.CONTACT_RETURN;
+      close(CONSOLE_SDK.CONTACT_RETURN);
     },
   };
 


### PR DESCRIPTION
Replace console.table (whose cell text DevTools always renders blue and JS can't restyle) with a styledTable helper that draws aligned columns via %c - command/primary column in phosphor green, prose warm. Applied to help(), impact(), and experience.

Route each command's closing line through a close() helper so the punchline logs in warm champagne instead of the browser's blue return-value echo (commands now return undefined).

Remove the redundant emoji section titles (e.g. "Reach me directly") from every command - the command you typed already names the section - and delete the now-unused *_TITLE constants.