### PR TITLE
fix: use :focus-visible for nav items so mouse clicks don't leave a l…

### DIFF
--- a/client/src/shared/components/navigation.module.css
+++ b/client/src/shared/components/navigation.module.css
@@ -92,7 +92,7 @@
   transform: scale(1.05);
 }
 
-.navigation__item:focus {
+.navigation__item:focus-visible {
   outline: var(--outline-width) solid var(--color-primary-400);
   outline-offset: var(--outline-offset);
 }
@@ -122,7 +122,7 @@
   color: var(--color-primary-400);
 }
 
-.navigation__mobile-toggle:focus {
+.navigation__mobile-toggle:focus-visible {
   outline: var(--outline-width) solid var(--color-primary-400);
   outline-offset: var(--outline-offset);
 }
@@ -198,7 +198,7 @@
   background: hsla(42, 30%, 88%, 0.12);
 }
 
-.navigation__mobile-item:focus {
+.navigation__mobile-item:focus-visible {
   outline: var(--outline-width) solid var(--color-primary-400);
   outline-offset: var(--outline-offset);
   color: var(--color-primary-400);


### PR DESCRIPTION
…ingering outline

Clicking a nav button kept :focus, so the focus outline stayed painted around the active item while scrolling. Switch nav items, mobile toggle, and mobile items to :focus-visible (matching the logo) — keyboard focus still shows the ring, mouse clicks no longer do.