### PR TITLE
feat: replace stock 404 with a URL-seeded maze page

### DIFF
--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -4,8 +4,7 @@ import { MotionConfig } from 'motion/react';
 import Home from '@/pages/home';
 import { CursorGlow } from '@/shared/components/cursor-glow';
 
-// Separate chunk: the 404 page (and the shadcn card it drags in) stays out
-// of the main bundle's critical path.
+// Separate chunk: the 404 page stays out of the main bundle's critical path.
 const NotFound = lazy(() => import('@/features/not-found/not-found'));
 
 function AppRoutes() {

--- a/client/src/features/not-found/not-found.module.css
+++ b/client/src/features/not-found/not-found.module.css
@@ -1,0 +1,277 @@
+/* ==========================================================================
+   404 Page - BEM Methodology
+   The broken URL seeds a maze ("tangle to clarity", applied to the error
+   state); the solution trail draws itself toward the exit that leads home.
+   ========================================================================== */
+
+/* Block: not-found */
+.not-found {
+  min-height: 100vh;
+  background-color: var(--color-neutral-950);
+  color: var(--color-neutral-100);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+
+/* Soft radial bloom behind the content, echoing the hero's figure-ground depth */
+.not-found::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(900px, 92%);
+  height: 620px;
+  background: radial-gradient(ellipse at center, hsla(42, 30%, 88%, 0.06) 0%, transparent 62%);
+  pointer-events: none;
+  z-index: var(--z-index-base);
+}
+
+/* The VK mark: the one piece of site chrome, and the quiet second exit */
+.not-found__home-mark {
+  position: absolute;
+  top: var(--spacing-6);
+  left: var(--spacing-6);
+  z-index: 2;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.04em;
+  color: var(--color-foreground);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+.not-found__home-mark:hover {
+  color: var(--color-primary-400);
+}
+
+.not-found__home-mark:focus-visible {
+  outline: var(--outline-width) solid var(--color-primary-400);
+  outline-offset: var(--outline-offset);
+}
+
+.not-found__main {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-20) var(--spacing-6);
+  position: relative;
+  z-index: 1;
+}
+
+.not-found__content {
+  max-width: var(--content-max-width-md);
+  width: 100%;
+}
+
+/* Desktop: copy column left, maze right - the hero's split, restated */
+@media (min-width: 1024px) {
+  .not-found__content {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas:
+      'kicker maze'
+      'title  maze'
+      'lead   maze'
+      'notes  maze'
+      'exits  maze';
+    column-gap: var(--spacing-16);
+    align-items: start;
+  }
+
+  .not-found__kicker {
+    grid-area: kicker;
+  }
+
+  .not-found__title {
+    grid-area: title;
+  }
+
+  .not-found__lead {
+    grid-area: lead;
+  }
+
+  .not-found__notes {
+    grid-area: notes;
+  }
+
+  .not-found__maze {
+    grid-area: maze;
+    place-self: center;
+    margin: 0;
+  }
+
+  .not-found__exits {
+    grid-area: exits;
+    align-self: end;
+  }
+}
+
+/* Same register as the section titles: small, tracked, warm muted mono */
+.not-found__kicker {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  color: var(--color-label-muted);
+  margin: 0 0 var(--spacing-10);
+}
+
+/* Display title, echoing the hero: solid line + stroke-outlined counterpart */
+.not-found__title {
+  font-family: var(--font-family-mono);
+  font-size: clamp(var(--font-size-3xl), 6vw, var(--font-size-5xl));
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  line-height: 1.05;
+  margin: 0 0 var(--spacing-6);
+  display: flex;
+  flex-direction: column;
+}
+
+.not-found__title-main {
+  color: var(--color-foreground);
+}
+
+.not-found__title-accent {
+  color: transparent;
+  -webkit-text-stroke: 1.5px var(--color-neutral-300);
+}
+
+.not-found__lead {
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-lg);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-neutral-300);
+  max-width: 52ch;
+  margin: 0 0 var(--spacing-10);
+}
+
+/* The broken path, set like the palette's kbd chip */
+.not-found__path {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-primary-400);
+  background: hsla(42, 30%, 88%, 0.06);
+  border: var(--border-width-thin) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-1) var(--spacing-2);
+  overflow-wrap: anywhere;
+}
+
+/* The maze: dim walls; the solution trail draws itself in cream.
+   Uses the platform monospace (NOT Space Mono): system mono ships full-cell
+   box-drawing glyphs that tile into continuous walls, whereas Space Mono's are
+   short and centred, so they render as broken, disconnected line segments.
+   line-height:1 + zero letter-spacing keep the grid seamless in both axes. */
+.not-found__maze {
+  font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-size: clamp(0.8rem, 2.4vw, 1.05rem);
+  line-height: 1;
+  letter-spacing: 0;
+  color: hsla(42, 14%, 42%, 0.85);
+  margin: 0 0 var(--spacing-4);
+  user-select: none;
+}
+
+.not-found__maze-step {
+  color: var(--color-primary-400);
+  font-weight: var(--font-weight-bold);
+  text-shadow: 0 0 12px hsla(42, 36%, 89%, 0.45);
+  opacity: 0;
+  animation: notFoundTrace 0.3s ease forwards;
+  /* Wait out the page entrance, then trace entrance→exit step by step */
+  animation-delay: calc(0.6s + var(--step) * 0.03s);
+}
+
+@keyframes notFoundTrace {
+  to {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .not-found__maze-step {
+    animation: none;
+    opacity: 1;
+  }
+}
+
+/* Seed note + AI note: comment-register mono, like approach.sh's comments */
+.not-found__note {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-relaxed);
+  color: hsl(42, 12%, 41%);
+  margin: 0 0 var(--spacing-2);
+  overflow-wrap: anywhere;
+}
+
+.not-found__exits {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-3);
+  margin-top: var(--spacing-10);
+}
+
+.not-found__exits-label {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--color-label-muted);
+  margin-right: var(--spacing-2);
+}
+
+/* Same recipe as the site's buttons: mono, uppercase, flat corners */
+.not-found__action {
+  padding: 0.875rem 1.75rem;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  border-radius: 0;
+  border: var(--border-width-thin) solid var(--color-border);
+  background: transparent;
+  color: var(--color-foreground);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  transition:
+    transform 0.2s var(--transition-curve),
+    box-shadow 0.2s var(--transition-curve),
+    background 0.2s ease-in-out,
+    border-color 0.2s ease-in-out;
+}
+
+.not-found__action:hover {
+  background: hsla(42, 30%, 88%, 0.06);
+  border-color: hsla(42, 30%, 88%, 0.5);
+}
+
+.not-found__action:focus-visible {
+  outline: var(--outline-width) solid var(--color-primary-400);
+  outline-offset: var(--outline-offset);
+}
+
+.not-found__action--primary {
+  background: var(--gradient-primary);
+  color: var(--color-primary-foreground);
+  border-color: transparent;
+}
+
+.not-found__action--primary:hover {
+  background: var(--gradient-primary);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-glow-blue-lg);
+}

--- a/client/src/features/not-found/not-found.tsx
+++ b/client/src/features/not-found/not-found.tsx
@@ -1,30 +1,123 @@
-import { useEffect } from 'react';
-import { Card, CardContent } from '@/shared/components/ui/card';
-import { AlertCircle } from 'lucide-react';
+import { useEffect, useMemo, type CSSProperties } from 'react';
+import { useLocation } from 'wouter';
+import { motion } from 'motion/react';
+import { ParticleSystem } from '@/shared/components/particle-system';
+import { generateMaze, hashString, seededRandom, MAZE_COLS, MAZE_ROWS } from '@/shared/lib/maze';
+import { logWrongTurn } from '@/shared/lib/console-signature';
+import { NOT_FOUND, PERSONAL_INFO } from '@/shared/constants/strings';
+import { ANIMATION_DURATION, INITIAL_OFFSET, OPACITY } from '@/shared/constants/layout';
+import { suggestSections, looksAiInvented } from './suggest-sections';
+import styles from './not-found.module.css';
 
 export default function NotFound() {
+  const [path] = useLocation();
+
+  // The broken URL is the seed: the same wrong turn always draws the same maze.
+  const maze = useMemo(
+    () => generateMaze(MAZE_COLS, MAZE_ROWS, seededRandom(hashString(path))),
+    [path],
+  );
+  const suggestions = useMemo(() => suggestSections(path), [path]);
+  const aiNote = suggestions.length === 0 && looksAiInvented(path);
+
   useEffect(() => {
     const previous = document.title;
-    document.title = '404 Page Not Found | Victoria Kirichenko';
+    document.title = NOT_FOUND.DOC_TITLE;
+    // Static hosts serve the SPA shell with a 200 for unknown paths (a soft
+    // 404); noindex keeps crawlers from treating dead URLs as real pages.
+    const robots = document.createElement('meta');
+    robots.name = 'robots';
+    robots.content = 'noindex';
+    document.head.appendChild(robots);
     return () => {
       document.title = previous;
+      robots.remove();
     };
   }, []);
 
+  useEffect(() => {
+    logWrongTurn(path);
+  }, [path]);
+
   return (
-    <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
-      <Card className="w-full max-w-md mx-4">
-        <CardContent className="pt-6">
-          <div className="flex mb-4 gap-2">
-            <AlertCircle className="h-8 w-8 text-red-500" aria-hidden="true" />
-            <h1 className="text-2xl font-bold text-gray-900">404 Page Not Found</h1>
+    <div className={styles['not-found']}>
+      <ParticleSystem />
+
+      <a className={styles['not-found__home-mark']} href="/" aria-label="Back to home">
+        {PERSONAL_INFO.INITIALS}
+      </a>
+
+      <main className={styles['not-found__main']}>
+        <motion.div
+          className={styles['not-found__content']}
+          initial={{ opacity: OPACITY.HIDDEN, y: INITIAL_OFFSET.Y_SMALL }}
+          animate={{ opacity: OPACITY.VISIBLE, y: 0 }}
+          transition={{ duration: ANIMATION_DURATION.NORMAL }}
+        >
+          <p className={styles['not-found__kicker']}>{NOT_FOUND.KICKER}</p>
+
+          <h1 className={styles['not-found__title']}>
+            <span className={styles['not-found__title-main']}>{NOT_FOUND.TITLE_MAIN}</span>
+            <span className={styles['not-found__title-accent']}>{NOT_FOUND.TITLE_ACCENT}</span>
+          </h1>
+
+          <p className={styles['not-found__lead']}>
+            <code className={styles['not-found__path']}>{path}</code>
+            {NOT_FOUND.LEAD_SUFFIX}
+          </p>
+
+          <pre className={styles['not-found__maze']} aria-hidden="true">
+            {maze.map((row, r) => (
+              <span key={r}>
+                {row.map((cell, c) =>
+                  cell.step != null ? (
+                    <span
+                      key={c}
+                      className={styles['not-found__maze-step']}
+                      style={{ '--step': cell.step } as CSSProperties}
+                    >
+                      {cell.ch}
+                    </span>
+                  ) : (
+                    cell.ch
+                  ),
+                )}
+                {'\n'}
+              </span>
+            ))}
+          </pre>
+
+          <div className={styles['not-found__notes']}>
+            <p className={styles['not-found__note']}>
+              {NOT_FOUND.MAZE_NOTE_PREFIX}
+              {`"${path}"`}
+              {NOT_FOUND.MAZE_NOTE_SUFFIX}
+            </p>
+            {aiNote && <p className={styles['not-found__note']}>{NOT_FOUND.AI_NOTE}</p>}
           </div>
 
-          <p className="mt-4 text-sm text-gray-600">
-            Did you forget to add the page to the router?
-          </p>
-        </CardContent>
-      </Card>
+          <nav className={styles['not-found__exits']} aria-label="Where to go instead">
+            {suggestions.length > 0 && (
+              <span className={styles['not-found__exits-label']}>{NOT_FOUND.SUGGEST_LABEL}</span>
+            )}
+            {suggestions.map((suggestion) => (
+              <a
+                key={suggestion.id}
+                className={styles['not-found__action']}
+                href={`/#${suggestion.id}`}
+              >
+                {suggestion.label}
+              </a>
+            ))}
+            <a
+              className={`${styles['not-found__action']} ${styles['not-found__action--primary']}`}
+              href="/"
+            >
+              {NOT_FOUND.HOME_ACTION} →
+            </a>
+          </nav>
+        </motion.div>
+      </main>
     </div>
   );
 }

--- a/client/src/features/not-found/suggest-sections.ts
+++ b/client/src/features/not-found/suggest-sections.ts
@@ -1,0 +1,94 @@
+/**
+ * Recovery suggestions for the 404 page: match the broken path's words against
+ * the real sections (plus the slugs people - and AI assistants - tend to guess)
+ * and rank the closest ones as "did you mean" exits.
+ */
+import { NAV_ITEMS } from '@/shared/constants/strings';
+
+export type SectionSuggestion = {
+  id: (typeof NAV_ITEMS)[number]['id'];
+  label: string;
+};
+
+// Plausible slugs → real section ids. Keys are what a visitor might type or an
+// AI might invent; values are the sections that actually answer that intent.
+const SECTION_ALIASES: Record<string, SectionSuggestion['id']> = {
+  about: 'about',
+  me: 'about',
+  bio: 'about',
+  story: 'about',
+  experience: 'experience',
+  resume: 'experience',
+  cv: 'experience',
+  career: 'experience',
+  history: 'experience',
+  philosophy: 'philosophy',
+  leadership: 'philosophy',
+  values: 'philosophy',
+  principles: 'philosophy',
+  projects: 'projects',
+  work: 'projects',
+  portfolio: 'projects',
+  cases: 'projects',
+  testimonials: 'testimonials',
+  references: 'testimonials',
+  recommendations: 'testimonials',
+  contact: 'contact',
+  hire: 'contact',
+  email: 'contact',
+  talk: 'contact',
+};
+
+function levenshtein(a: string, b: string): number {
+  const prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    let diag = prev[0];
+    prev[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const next = Math.min(prev[j] + 1, prev[j - 1] + 1, diag + (a[i - 1] === b[j - 1] ? 0 : 1));
+      diag = prev[j];
+      prev[j] = next;
+    }
+  }
+  return prev[b.length];
+}
+
+/** Words a path is made of: "/my-work/2024" → ["my", "work", "2024"]. */
+function pathWords(pathname: string): string[] {
+  return pathname
+    .toLowerCase()
+    .split(/[/\-_.]+/)
+    .filter(Boolean);
+}
+
+export function suggestSections(pathname: string, max = 2): SectionSuggestion[] {
+  const words = pathWords(pathname);
+  if (words.length === 0) return [];
+
+  const best = new Map<SectionSuggestion['id'], number>();
+  for (const [alias, id] of Object.entries(SECTION_ALIASES)) {
+    // Tiny aliases must match exactly (fuzzy "me" would swallow "my", "be"…);
+    // short ones forgive one slip; longer ones forgive two.
+    const tolerance = alias.length <= 3 ? 0 : alias.length >= 6 ? 2 : 1;
+    const distance = Math.min(...words.map((word) => levenshtein(word, alias)));
+    if (distance > tolerance) continue;
+    const prior = best.get(id);
+    if (prior == null || distance < prior) best.set(id, distance);
+  }
+
+  return Array.from(best.entries())
+    .sort((a, b) => a[1] - b[1])
+    .slice(0, max)
+    .map(([id]) => ({ id, label: NAV_ITEMS.find((item) => item.id === id)?.label ?? id }));
+}
+
+/**
+ * A multi-segment or long compound slug reads like a URL an AI assistant
+ * invented (they hallucinate deep links, not typos). Only meaningful when
+ * nothing fuzzy-matched - a near-miss is just a typo.
+ */
+export function looksAiInvented(pathname: string): boolean {
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments.length >= 2) return true;
+  return (segments[0]?.split(/[-_]/).length ?? 0) >= 3;
+}

--- a/client/src/pages/home/index.tsx
+++ b/client/src/pages/home/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { ParticleSystem } from '@/shared/components/particle-system';
 import { Navigation } from '@/shared/components/navigation';
+import { SCROLL_BEHAVIOR } from '@/shared/constants/strings';
 import { mountConsoleSignature } from '@/shared/lib/console-signature';
 import { Hero } from '@/features/hero/hero';
 import { About } from '@/features/about/about';
@@ -16,6 +17,39 @@ export default function Home() {
   // Install the interactive console experience for fellow developers (window.victoria).
   useEffect(() => {
     mountConsoleSignature();
+  }, []);
+
+  // A deep link like /#experience (e.g. an exit from the 404 page) loads the SPA
+  // fresh, and the browser's native hash-scroll fires before React has rendered
+  // the sections - so it lands at the top. Re-run the scroll ourselves, then
+  // re-assert once late assets (web fonts, the hero portrait) settle and the
+  // final page height is known.
+  useEffect(() => {
+    const id = decodeURIComponent(window.location.hash.slice(1));
+    if (!id) return;
+    let cancelled = false;
+    const scrollToTarget = () => {
+      if (cancelled) return;
+      // 'instant', NOT 'auto': the page sets a global `scroll-behavior: smooth`,
+      // and 'auto' defers to that CSS - so an in-flight smooth animation gets
+      // interrupted by the next settle signal and never lands. 'instant' forces
+      // an immediate jump that can't be chased or overshoot.
+      document
+        .getElementById(id)
+        ?.scrollIntoView({ block: SCROLL_BEHAVIOR.BLOCK_START, behavior: 'instant' });
+    };
+    const raf = requestAnimationFrame(scrollToTarget);
+    document.fonts?.ready.then(scrollToTarget);
+    if (document.readyState === 'complete') {
+      scrollToTarget();
+    } else {
+      window.addEventListener('load', scrollToTarget, { once: true });
+    }
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+      window.removeEventListener('load', scrollToTarget);
+    };
   }, []);
 
   return (

--- a/client/src/shared/constants/strings.ts
+++ b/client/src/shared/constants/strings.ts
@@ -77,6 +77,23 @@ export const BUTTON_LABELS = {
   LEARN_MORE: 'Learn More',
 } as const;
 
+// 404 Page - the broken URL seeds a maze (the "tangle to clarity" motif, applied
+// to the error state): every wrong turn gets its own tangle, and its one way out.
+export const NOT_FOUND = {
+  DOC_TITLE: '404 Page Not Found | Victoria Kirichenko',
+  KICKER: 'ERROR 404 - PAGE NOT FOUND',
+  TITLE_MAIN: 'Wrong turn.',
+  TITLE_ACCENT: 'Not a wasted one.',
+  LEAD_SUFFIX: " isn't a page here. But every tangle has a way through - this one leads home.",
+  MAZE_NOTE_PREFIX: '// maze seeded from ',
+  MAZE_NOTE_SUFFIX: ' - every wrong turn gets its own',
+  AI_NOTE: '// if an AI sent you here, it invented this URL. The exits below are real.',
+  SUGGEST_LABEL: 'Did you mean',
+  HOME_ACTION: 'Take the exit',
+  CONSOLE_PREFIX: '// wrong turn: ',
+  CONSOLE_SUFFIX: ' - solvable, like everything else. try victoria.maze()',
+} as const;
+
 // Console Messages
 export const CONSOLE_MESSAGES = {
   WELCOME_TITLE: "🚀 Welcome to Victoria Kirichenko's Portfolio!",

--- a/client/src/shared/lib/console-signature.ts
+++ b/client/src/shared/lib/console-signature.ts
@@ -12,7 +12,9 @@ import {
   LEADERSHIP_PRINCIPLES,
   CONSOLE_MESSAGES,
   CONSOLE_SDK,
+  NOT_FOUND,
 } from '@/shared/constants/strings';
+import { generateMaze, MAZE_COLS, MAZE_ROWS } from '@/shared/lib/maze';
 
 const STYLE = {
   title: `color:${CONSOLE_PALETTE.TITLE};font-size:${CONSOLE_FONT_SIZE.LARGE};font-weight:bold;`,
@@ -71,128 +73,17 @@ function styledTable(rows: readonly Record<string, unknown>[], columns: TableCol
 
 // --- victoria.maze(): a fresh, always-solvable maze with its one path traced ---
 // Same idea as the site's "tangle to clarity" motif: there's always a way through.
-const MAZE_COLS = 11;
-const MAZE_ROWS = 9;
-
-// Box-drawing glyph for a wall cell, keyed by which of its up/down/left/right
-// neighbours are also walls (1 = connected). Correct junctions = no floating stubs.
-const MAZE_BOX: Record<string, string> = {
-  '0000': ' ',
-  '0001': '╶',
-  '0010': '╴',
-  '0011': '─',
-  '0100': '╷',
-  '0101': '┌',
-  '0110': '┐',
-  '0111': '┬',
-  '1000': '╵',
-  '1001': '└',
-  '1010': '┘',
-  '1011': '┴',
-  '1100': '│',
-  '1101': '├',
-  '1110': '┤',
-  '1111': '┼',
-};
-
-/**
- * Generate a random maze (recursive backtracker) on a (2·cols+1)×(2·rows+1) grid,
- * solve it entrance→exit with BFS, and return thin-line rows. Walls become box
- * glyphs, the solution is a "·" trail, and the exit is marked with "→".
- */
-function generateMaze(cols: number, rows: number): string[] {
-  const W = 2 * cols + 1;
-  const H = 2 * rows + 1;
-  const g: string[][] = Array.from({ length: H }, () => Array<string>(W).fill('#'));
-  const visited: boolean[][] = Array.from({ length: rows }, () => Array<boolean>(cols).fill(false));
-
-  const carve = (cx: number, cy: number): void => {
-    visited[cy][cx] = true;
-    g[2 * cy + 1][2 * cx + 1] = ' ';
-    const dirs = [
-      [0, -1],
-      [1, 0],
-      [0, 1],
-      [-1, 0],
-    ];
-    for (let i = dirs.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [dirs[i], dirs[j]] = [dirs[j], dirs[i]];
-    }
-    for (const [dx, dy] of dirs) {
-      const nx = cx + dx;
-      const ny = cy + dy;
-      if (nx < 0 || ny < 0 || nx >= cols || ny >= rows || visited[ny][nx]) continue;
-      g[2 * cy + 1 + dy][2 * cx + 1 + dx] = ' ';
-      carve(nx, ny);
-    }
-  };
-  carve(0, 0);
-
-  g[1][0] = ' '; // entrance: left edge, top row
-  g[H - 2][W - 1] = ' '; // exit: right edge, bottom row
-
-  // BFS for the shortest entrance→exit path (a single, non-branching trail).
-  const key = (r: number, c: number) => r * W + c;
-  const prev = new Map<number, number | null>();
-  const queue: Array<[number, number]> = [[1, 0]];
-  prev.set(key(1, 0), null);
-  const end = key(H - 2, W - 1);
-  while (queue.length) {
-    const [r, c] = queue.shift() as [number, number];
-    if (key(r, c) === end) break;
-    for (const [dr, dc] of [
-      [0, 1],
-      [1, 0],
-      [0, -1],
-      [-1, 0],
-    ]) {
-      const nr = r + dr;
-      const nc = c + dc;
-      if (nr < 0 || nc < 0 || nr >= H || nc >= W) continue;
-      if (g[nr][nc] === '#' || prev.has(key(nr, nc))) continue;
-      prev.set(key(nr, nc), key(r, c));
-      queue.push([nr, nc]);
-    }
-  }
-  for (let cur: number | null | undefined = end; cur != null; cur = prev.get(cur)) {
-    const r = Math.floor(cur / W);
-    const c = cur % W;
-    if (g[r][c] === ' ') g[r][c] = '·';
-  }
-
-  const isWall = (r: number, c: number) => r >= 0 && c >= 0 && r < H && c < W && g[r][c] === '#';
-  const out: string[] = [];
-  for (let r = 0; r < H; r++) {
-    let row = '';
-    for (let c = 0; c < W; c++) {
-      const ch = g[r][c];
-      if (ch === '#') {
-        const u = isWall(r - 1, c) ? 1 : 0;
-        const d = isWall(r + 1, c) ? 1 : 0;
-        const l = isWall(r, c - 1) ? 1 : 0;
-        const ri = isWall(r, c + 1) ? 1 : 0;
-        row += MAZE_BOX[`${u}${d}${l}${ri}`];
-      } else {
-        row += ch;
-      }
-    }
-    out.push(row);
-  }
-  out[H - 2] += '→'; // point the way out
-  return out;
-}
+// The generator itself lives in shared/lib/maze.ts, where the 404 page reuses it.
 
 /** Print the maze in two tones: dim walls, champagne solution path. */
 function drawMaze(): void {
-  const rows = generateMaze(MAZE_COLS, MAZE_ROWS);
+  const grid = generateMaze(MAZE_COLS, MAZE_ROWS);
   const wallStyle = `color:${CONSOLE_PALETTE.DIM};`;
   const pathStyle = `color:${CONSOLE_PALETTE.ACCENT};font-weight:bold;`;
-  const isPath = (ch: string) => ch === '·' || ch === '→';
 
   let fmt = '';
   const styles: string[] = [];
-  rows.forEach((row, i) => {
+  grid.forEach((row, i) => {
     let run = '';
     let runIsPath = false;
     const flush = () => {
@@ -201,14 +92,14 @@ function drawMaze(): void {
       styles.push(runIsPath ? pathStyle : wallStyle);
       run = '';
     };
-    for (const ch of row) {
-      const p = isPath(ch);
+    for (const cell of row) {
+      const p = cell.step != null;
       if (run && p !== runIsPath) flush();
       runIsPath = p;
-      run += ch;
+      run += cell.ch;
     }
     flush();
-    if (i < rows.length - 1) fmt += '\n';
+    if (i < grid.length - 1) fmt += '\n';
   });
   console.log(fmt, ...styles);
 }
@@ -338,4 +229,10 @@ export function mountConsoleSignature(): void {
   greet();
 
   (window as unknown as { victoria: ReturnType<typeof buildApi> }).victoria = buildApi();
+}
+
+/** 404 hook: install the SDK, then note the wrong turn in the console's voice. */
+export function logWrongTurn(path: string): void {
+  mountConsoleSignature();
+  line(`${NOT_FOUND.CONSOLE_PREFIX}"${path}"${NOT_FOUND.CONSOLE_SUFFIX}`, STYLE.comment);
 }

--- a/client/src/shared/lib/maze.test.ts
+++ b/client/src/shared/lib/maze.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { generateMaze, hashString, seededRandom, MAZE_COLS, MAZE_ROWS } from './maze';
+
+const seeded = (path: string) => generateMaze(MAZE_COLS, MAZE_ROWS, seededRandom(hashString(path)));
+
+const render = (grid: ReturnType<typeof generateMaze>) =>
+  grid.map((row) => row.map((cell) => cell.ch).join('')).join('\n');
+
+describe('generateMaze', () => {
+  it('is deterministic for the same seed and distinct across seeds', () => {
+    expect(render(seeded('/resume'))).toBe(render(seeded('/resume')));
+    expect(render(seeded('/resume'))).not.toBe(render(seeded('/projects')));
+  });
+
+  it('traces one continuous entrance→exit trail', () => {
+    const grid = seeded('/anything');
+    const steps = new Map<number, [number, number]>();
+    grid.forEach((row, r) =>
+      row.forEach((cell, c) => {
+        if (cell.step != null) {
+          expect(steps.has(cell.step)).toBe(false);
+          steps.set(cell.step, [r, c]);
+        }
+      }),
+    );
+
+    // Entrance is the left edge of the top corridor row; steps are contiguous
+    // and each consecutive pair is grid-adjacent (the trailing "→" marker sits
+    // one column past the exit, still adjacency-1 from it).
+    expect(steps.get(0)).toEqual([1, 0]);
+    for (let i = 1; i < steps.size; i++) {
+      const [pr, pc] = steps.get(i - 1)!;
+      const [r, c] = steps.get(i)!;
+      expect(Math.abs(r - pr) + Math.abs(c - pc)).toBe(1);
+    }
+  });
+});

--- a/client/src/shared/lib/maze.ts
+++ b/client/src/shared/lib/maze.ts
@@ -1,0 +1,153 @@
+/**
+ * Maze generation - shared by the console easter egg (victoria.maze()) and the
+ * 404 page. The generator takes a random source, so the console gets a fresh
+ * tangle every call while the 404 page seeds it from the broken URL: every
+ * wrong turn gets its own maze, and the same wrong turn always gets the same one.
+ */
+
+export const MAZE_COLS = 11;
+export const MAZE_ROWS = 9;
+
+export type MazeCell = {
+  ch: string;
+  /** Position along the entrance→exit solution trail, or null off the trail. */
+  step: number | null;
+};
+
+// Box-drawing glyph for a wall cell, keyed by which of its up/down/left/right
+// neighbours are also walls (1 = connected). Correct junctions = no floating stubs.
+const MAZE_BOX: Record<string, string> = {
+  '0000': ' ',
+  '0001': '╶',
+  '0010': '╴',
+  '0011': '─',
+  '0100': '╷',
+  '0101': '┌',
+  '0110': '┐',
+  '0111': '┬',
+  '1000': '╵',
+  '1001': '└',
+  '1010': '┘',
+  '1011': '┴',
+  '1100': '│',
+  '1101': '├',
+  '1110': '┤',
+  '1111': '┼',
+};
+
+/** xmur3-style string hash → 32-bit seed. */
+export function hashString(input: string): number {
+  let h = 1779033703 ^ input.length;
+  for (let i = 0; i < input.length; i++) {
+    h = Math.imul(h ^ input.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  h = Math.imul(h ^ (h >>> 16), 2246822507);
+  h = Math.imul(h ^ (h >>> 13), 3266489909);
+  return (h ^ (h >>> 16)) >>> 0;
+}
+
+/** mulberry32 - a tiny deterministic PRNG over a 32-bit seed. */
+export function seededRandom(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Generate a maze (recursive backtracker) on a (2·cols+1)×(2·rows+1) grid,
+ * solve it entrance→exit with BFS, and return the grid as cells. Walls become
+ * box glyphs, the solution is a "·" trail (ordered by `step`), and the exit
+ * row carries a trailing "→" pointing the way out.
+ */
+export function generateMaze(
+  cols: number,
+  rows: number,
+  random: () => number = Math.random,
+): MazeCell[][] {
+  const W = 2 * cols + 1;
+  const H = 2 * rows + 1;
+  const g: string[][] = Array.from({ length: H }, () => Array<string>(W).fill('#'));
+  const visited: boolean[][] = Array.from({ length: rows }, () => Array<boolean>(cols).fill(false));
+
+  const carve = (cx: number, cy: number): void => {
+    visited[cy][cx] = true;
+    g[2 * cy + 1][2 * cx + 1] = ' ';
+    const dirs = [
+      [0, -1],
+      [1, 0],
+      [0, 1],
+      [-1, 0],
+    ];
+    for (let i = dirs.length - 1; i > 0; i--) {
+      const j = Math.floor(random() * (i + 1));
+      [dirs[i], dirs[j]] = [dirs[j], dirs[i]];
+    }
+    for (const [dx, dy] of dirs) {
+      const nx = cx + dx;
+      const ny = cy + dy;
+      if (nx < 0 || ny < 0 || nx >= cols || ny >= rows || visited[ny][nx]) continue;
+      g[2 * cy + 1 + dy][2 * cx + 1 + dx] = ' ';
+      carve(nx, ny);
+    }
+  };
+  carve(0, 0);
+
+  g[1][0] = ' '; // entrance: left edge, top row
+  g[H - 2][W - 1] = ' '; // exit: right edge, bottom row
+
+  // BFS for the shortest entrance→exit path (a single, non-branching trail).
+  const key = (r: number, c: number) => r * W + c;
+  const prev = new Map<number, number | null>();
+  const queue: Array<[number, number]> = [[1, 0]];
+  prev.set(key(1, 0), null);
+  const end = key(H - 2, W - 1);
+  while (queue.length) {
+    const [r, c] = queue.shift() as [number, number];
+    if (key(r, c) === end) break;
+    for (const [dr, dc] of [
+      [0, 1],
+      [1, 0],
+      [0, -1],
+      [-1, 0],
+    ]) {
+      const nr = r + dr;
+      const nc = c + dc;
+      if (nr < 0 || nc < 0 || nr >= H || nc >= W) continue;
+      if (g[nr][nc] === '#' || prev.has(key(nr, nc))) continue;
+      prev.set(key(nr, nc), key(r, c));
+      queue.push([nr, nc]);
+    }
+  }
+  const trail: number[] = [];
+  for (let cur: number | null | undefined = end; cur != null; cur = prev.get(cur)) {
+    trail.push(cur);
+  }
+  trail.reverse();
+  const stepOf = new Map<number, number>(trail.map((k, i) => [k, i]));
+
+  const isWall = (r: number, c: number) => r >= 0 && c >= 0 && r < H && c < W && g[r][c] === '#';
+  const out: MazeCell[][] = [];
+  for (let r = 0; r < H; r++) {
+    const row: MazeCell[] = [];
+    for (let c = 0; c < W; c++) {
+      if (g[r][c] === '#') {
+        const u = isWall(r - 1, c) ? 1 : 0;
+        const d = isWall(r + 1, c) ? 1 : 0;
+        const l = isWall(r, c - 1) ? 1 : 0;
+        const ri = isWall(r, c + 1) ? 1 : 0;
+        row.push({ ch: MAZE_BOX[`${u}${d}${l}${ri}`], step: null });
+      } else {
+        const step = stepOf.get(key(r, c)) ?? null;
+        row.push({ ch: step != null ? '·' : ' ', step });
+      }
+    }
+    out.push(row);
+  }
+  out[H - 2].push({ ch: '→', step: trail.length }); // point the way out
+  return out;
+}


### PR DESCRIPTION
The catch-all NotFound was a stock shadcn card ("Did you forget to add the page to the router?") - off-brand for the site's warm-dark brutalist voice. Replace it with a page that performs the "tangle to clarity" motif on the error state: the broken URL seeds a box-drawing maze (same wrong turn -> same maze), whose solution trail draws itself toward an exit that leads home.

- Extract the console easter egg's maze generator into shared/lib/maze.ts, made seedable (xmur3 + mulberry32) so victoria.maze() stays random while the 404 is deterministic per path. Cover it with maze.test.ts.
- Fuzzy "did you mean" recovery: Levenshtein-match the broken path's words against real sections (+ slugs people/AIs guess) and rank the closest.
- Flag likely AI-hallucinated deep links; log the wrong turn in the console SDK's voice; inject noindex to mitigate static-host soft-404s.
- Render the maze in a system-mono stack with line-height:1 so box-drawing glyphs tile into continuous walls (Space Mono's don't).

Also fix hash deep links (e.g. the 404's section exits): the SPA's native hash-scroll fires before React renders the sections, so /#experience landed at the top. Re-run the scroll on mount and re-assert on fonts.ready/load, using behavior:'instant' since the page's global scroll-behavior:smooth made 'auto' animate and get interrupted mid-load.