### PR TITLE
fix: keep projects search caret and text still on focus

### DIFF
--- a/client/src/features/projects/projects.tsx
+++ b/client/src/features/projects/projects.tsx
@@ -124,17 +124,22 @@ export function Projects() {
             <span className={styles['projects__palette-kbd']} aria-hidden="true">
               &#8984;K
             </span>
-            <span className={styles['projects__palette-caret']} aria-hidden="true" />
-            <input
-              ref={inputRef}
-              type="text"
-              className={styles['projects__palette-input']}
-              placeholder={PROJECTS_PALETTE.PLACEHOLDER}
-              aria-label={PROJECTS_PALETTE.ARIA_LABEL}
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              onKeyDown={handleSearchKeyDown}
-            />
+            <div className={styles['projects__palette-field']}>
+              {/* Decorative caret stays put while the field is empty (blurred or
+                  focused); the native caret only appears once you type, so a
+                  click never moves the cursor or the text */}
+              {!query && <span className={styles['projects__palette-caret']} aria-hidden="true" />}
+              <input
+                ref={inputRef}
+                type="text"
+                className={styles['projects__palette-input']}
+                placeholder={PROJECTS_PALETTE.PLACEHOLDER}
+                aria-label={PROJECTS_PALETTE.ARIA_LABEL}
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                onKeyDown={handleSearchKeyDown}
+              />
+            </div>
           </div>
 
           <div className={styles['projects__palette-results']}>

--- a/client/src/pages/home/home.module.css
+++ b/client/src/pages/home/home.module.css
@@ -1431,6 +1431,17 @@
   padding: var(--spacing-1) var(--spacing-2);
 }
 
+/* The field wraps the input and its idle caret so the caret can overlay the
+   input's text-start instead of living in the flex flow (which shifted the
+   text and made the caret hop on focus) */
+.projects__palette-field {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+}
+
 .projects__palette-input {
   flex: 1;
   min-width: 0;
@@ -1448,23 +1459,28 @@
   color: var(--color-neutral-400);
 }
 
+/* While the field is empty the decorative caret stands in for the cursor, so
+   suppress the native one to avoid two carets (and any jump on focus) */
+.projects__palette-input:placeholder-shown {
+  caret-color: transparent;
+}
+
 /* The input has no outline of its own; the search row signals focus instead */
 .projects__palette-search:focus-within {
   border-bottom-color: var(--color-border);
 }
 
-/* Blinking caret invites typing while the field is idle; the real caret
-   takes over on focus */
+/* Blinking caret invites typing while the field is idle; it overlays the
+   input's text-start so the native caret takes over on focus with no jump */
 .projects__palette-caret {
+  position: absolute;
+  left: calc(-1 * var(--spacing-2));
+  top: 50%;
+  transform: translateY(-50%);
   width: 1px;
   height: 1.1em;
   background: var(--color-primary-400);
-  margin-right: calc(-1 * var(--spacing-2));
   animation: projectsCaret 1.1s steps(1) infinite;
-}
-
-.projects__palette-search:focus-within .projects__palette-caret {
-  display: none;
 }
 
 @keyframes projectsCaret {


### PR DESCRIPTION
The command-palette search caret lived in the flex flow with a negative-margin hack. On focus the caret was removed (display:none), reclaiming its gap and shifting the placeholder text ~5px; a later visibility swap still left the fake caret and native cursor at different x, so the cursor hopped on click.

Move the decorative caret to an absolute overlay pinned before the text, keep it rendered while the field is empty, and suppress the native caret via :placeholder-shown until the user types. Clicking the empty field now moves neither the text nor the cursor.