### PR TITLE
refactor(cat): glyph-texture sprite from silhouette masks

### DIFF
--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -6,12 +6,19 @@ import { CursorGlow } from '@/shared/components/cursor-glow/cursor-glow';
 
 // Separate chunk: the 404 page stays out of the main bundle's critical path.
 const NotFound = lazy(() => import('@/features/not-found/not-found'));
+// Likewise the /cat easter egg - a hidden gem shouldn't weigh on the homepage.
+const CatPlayground = lazy(() => import('@/features/cat/cat-playground'));
 
 function AppRoutes() {
   return (
     <div className="dark">
       <Switch>
         <Route path="/" component={Home} />
+        <Route path="/cat">
+          <Suspense fallback={null}>
+            <CatPlayground />
+          </Suspense>
+        </Route>
         <Route>
           <Suspense fallback={null}>
             <NotFound />

--- a/client/src/features/cat/cat-frames.ts
+++ b/client/src/features/cat/cat-frames.ts
@@ -1,162 +1,245 @@
 /**
- * The cat. When she sits, she IS the reference art - transcribed verbatim,
- * character by character, not approximated. Generation is reserved for what
- * the reference doesn't have: the walking frames, whose glyph noise is rolled
- * from the same alphabet so the two styles read as one animal.
+ * The cat's frames, rebuilt to match the glyph-texture reference renders:
+ * a fluffy long-haired cat whose whole body is dense character noise
+ * (9s, 8s, S's...) with lighter punctuation along the edges and loose fur
+ * wisps just outside the silhouette.
+ *
+ * Frames are silhouette MASKS ('#' = cat), generated offline from ellipse /
+ * polygon / tapered-stroke geometry and baked here. Each render fills the
+ * mask with fresh glyph noise, so the fur shimmers frame to frame exactly
+ * like the reference sheets. Both poses face left natively; the right-facing
+ * sets are mirrored masks (the references include both directions).
+ *
+ *   A. Sitting  - one pose per direction; idle life comes from periodic
+ *                 noise re-rolls (the fur breathes) rather than keyframes.
+ *   B. Walking  - an 8-frame leg cycle per direction. The body and plume
+ *                 tail are the baked mask; the legs are placed per frame by
+ *                 a lateral-walk gait (footfalls a quarter-cycle apart,
+ *                 planted paws sweeping back at exactly ground speed).
  */
 
-/**
- * The reference, verbatim: a Maine Coon sitting in profile facing left, tail
- * lying along the ground to the right with the tip curling up at the end.
- */
-export const CAT_SIT_ART: readonly string[] = [
-  '3/              %',
-  ' G%          Rs',
-  ' @^%RK(^@@R3',
-  ' @#// ^^~%~/t(',
-  ' tC // sStt^~(',
-  '@@@@@@@@@R7 (s7',
-  '@t~%~R@Ct^(@(3Q',
-  '7~7R@^(e(/C%@C/^/#@',
-  '  @@C#SSs#@7//((%@',
-  ' KR@@@@S@C//%(@RsSG',
-  'QQQ@#eQt%%SRK@OO%G#KS',
-  'OSsO#RG%O#tR~@7tt%SsORS%',
-  ' OtKRSK3CS(Ot/(((CKt/%OsK(/t',
-  'tG@(eRK(/7~/t%7st~  /( (tCC^%',
-  ' 3O%O--^(~/t77OS~  (^^   ~(((/^t',
-  ' tt%t(%COt(C%t(  ^ //^   ^//~(sC/',
-  ' t%(tsQtt(Ss^^ ~ /~O(^      ^~%SQ',
-  '  es%%COK7^ /t7tOQ%3/     ^(((%SQK',
-  '  (SKS%3%~(#7COG(OOs / ^  /t%O3SQS',
-  '    SRKOS%3(%7sSOK(/~// ^(%OeGC3Q@Q',
-  '      (#RGCO%~t%eS  ((/(sCKt///t3Q@',
-  '       S CO~~S#sOe%ts%(t#%/^^/(t3e@',
-  '        KK^/teOK@@SOOt%t(///~/~tG%@@',
-  '         #O//7%S@G@@@%CS(///(t((SQs@@@      ^/t7eCt',
-  '         K/^~3R@@#%tKKC7/~//t%OQ%C@@@Rs3%/ t//~%%((C%(%st/',
-  '        S% /tS@@(tC3%(%t(7%eSQC%eQQR%O3t((tCC(t%Ot//(%%t// /(%/(',
-  '        s(^(s#@     /s@SCOOs@#C3(CR@ssKCC%O@Ct(t%OsO3SSOeSQRG%(t%t',
-  '       O//3CR@@    S( ~K@@@@@@R#@@@@ @@@R@@@@#@@@R@@@@@@@@@Q@G^ (CS%',
-  '      (~%StCs/       SKS                                %  ^/t%Gt',
-  '                                                          O tt#s%%',
+/* ==========================================================================
+   Baked silhouette masks (generated from geometry, facing left)
+   ========================================================================== */
+
+export const SIT_MASK: readonly string[] = [
+  '           ##           ###',
+  '            ###        ####',
+  '            ####       ####',
+  '             #####    ######',
+  '             ###############',
+  '              ###########',
+  '            ###############',
+  '            ###############',
+  '         #####   ###########',
+  '      # ####################',
+  '    #   ####################',
+  '     #  ####################',
+  '         ####################',
+  '       # #####################',
+  '          ###################       #',
+  '          ################## ###############',
+  '          #####################################',
+  '          #######################################',
+  '         ##########################################',
+  '         ############################################',
+  '         #############################################',
+  '        ###############################################',
+  '        ###############################################',
+  '        ################################################',
+  '       ##################################################',
+  '       ##################################################',
+  '       ##################################################',
+  '       ##################################################',
+  '       ###################################################',
+  '       ####################################################',
+  '       ####################################################',
+  '       ####################################################',
+  '       #####################################################                 ######',
+  '       ####################################################                 ########',
+  '      #####################################################               ##########',
+  '       ####################################################             ###########',
+  '       ###################################################            #############',
+  '        ####################################################### ##################',
+  '         #########################################################################',
+  '           ######################################################################',
+  '           ######################################################################',
+  '          #################  ###################################################',
+  '         ####################       #       #       ##########################',
+  '           #######  #######                             ##################',
 ];
 
-/**
- * The idle flick: same art, tail tip lifted off the ground for a beat. Only
- * the last two rows differ from the reference - everything else stays exact.
- */
-export const CAT_SIT_ART_FLICK: readonly string[] = [
-  ...CAT_SIT_ART.slice(0, 28),
-  '      (~%StCs/       SKS                                %  ^/t%GtO#s%',
-  '',
-];
-
-/** The reference's alphabet, split by visual weight - used by the walk frames. */
-const GLYPH_EDGE = '(/^~-t%s(',
-  GLYPH_MID = 'C3est7sKtO%',
-  GLYPH_DENSE = '@#RKQSGO';
-
-/** Chance any walk-frame cell renders as a gap - the "fur" holes. */
-const DROPOUT = 0.08;
-
-/**
- * Mid-stride walking profile, facing left, modelled on the prowling reference:
- * a walking cat is LOW - about two-thirds of her sitting height - and LONG,
- * with a level back, head carried at back height, tall tufted ears, whisker
- * wisps off the muzzle, a deep shaggy belly, and the signature Maine Coon tail:
- * a fat plume raised behind her, nearly ear-high. Head width matches the
- * sitting art's head, so the get-up reads as the same animal changing posture,
- * not changing size. Two stride frames (legs extended / gathering) share this
- * body, so only the legs move. The lone cells ahead of the muzzle render as
- * light isolated glyphs - the whiskers.
- */
+/** Walk body + tail; rows 30-39 are the leg zone, filled per frame below. */
 const WALK_BODY: readonly string[] = [
-  '    ##   ##                                         #####',
-  '   ###   ###                                      ########',
-  '   ##########                                    #########',
-  '  ############                                  #########',
-  '  ############                                 ########',
-  '# #############                               ########',
-  ' ###############                              #######',
-  '# ###############                            #######',
-  '   ################                         #######',
-  '    ####################################### ######',
-  '    ##############################################',
-  '     #############################################',
-  '     ############################################',
-  '      ##########################################',
-  '      ########################################',
+  '                     #',
+  '     #              ##',
+  '     ###            ##',
+  '     ####          ####                                                            ###',
+  '      #####       #####                                                      #############',
+  '      ######      #####                                                 ###################',
+  '      ########   #######                                              ######################',
+  '       #################                                             #######################',
+  '       #############                                                ########################',
+  '       ###############                                             #########################',
+  '       ###############                                            ##########################',
+  '    ####   ############    #                #                    ###########################',
+  '  ###################################################### # #########################',
+  '#  ##############################################################################',
+  ' # ###########################################################################',
+  '    ########################################################################',
+  '   # ####################################################################',
+  '     ####################################################################',
+  '      ####################################################################',
+  '        ##################################################################',
+  '          ################################################################',
+  '          #################################################################',
+  '          ################################################################',
+  '         #################################################################',
+  '          ################################################################',
+  '          ###############################################################',
+  '          ###############################################################',
+  '           #############################################################',
+  '             #########################################################',
+  '              ###########  # ########################################',
 ];
 
-export const CAT_MASK_WALK_A: readonly string[] = [
-  ...WALK_BODY,
-  '      ######   #######        #######   ######',
-  '     ######     ######        ######     #####',
-  '     #####       #####        #####       #####',
-  '    #####        ####         ####         ####',
-  '    ####         ####         ####          ####',
-  '   #####         ####         ####          #####',
-];
+/** Widest column any frame can reach. The component uses this to convert
+    the sprite's rendered width into a per-column pixel size. */
+export const WALK_MASK_WIDTH = 92;
+const WALK_ROWS = 40;
+const LEG_TOP = 30;
 
-export const CAT_MASK_WALK_B: readonly string[] = [
-  ...WALK_BODY,
-  '        ##### #######          ####### ######',
-  '        ####   ######          ######   #####',
-  '        ####    #####          #####    ####',
-  '        ####    #####          #####    ####',
-  '        ####    ####           ####     ####',
-  '       #####    ####           ####    #####',
-];
+/* ==========================================================================
+   Walk legs - a generated lateral-walk gait, 8 frames
+   ========================================================================== */
+
+/** How far a paw swings from its hip at full stride, in columns. */
+const STRIDE_SWEEP = 4;
+
+/** Fraction of the cycle each paw spends planted. Real cats walk at ~0.6:
+    always at least two paws down, never a bunched or floating moment. */
+const STANCE_SHARE = 0.6;
+
+/** Ground the body covers in one full leg cycle, in mask columns. Keying
+    the animation to this (see the component) is what stops paws from
+    sliding: the ground and the planted paws move at exactly the same rate. */
+export const WALK_CYCLE_COLS = (2 * STRIDE_SWEEP) / STANCE_SHARE;
+
+/** Hip anchors (columns, left-facing) and footfall offsets in lateral-walk
+    order. Near legs render wider than far legs for depth. */
+const LEGS = [
+  { anchor: 22, offset: 0.25, width: 3 }, // near front
+  { anchor: 30, offset: 0.75, width: 2 }, // far front
+  { anchor: 55, offset: 0.0, width: 3 }, // near rear
+  { anchor: 63, offset: 0.5, width: 2 }, // far rear
+] as const;
+
+function buildWalkMask(phase: number): readonly string[] {
+  const legs: string[][] = Array.from({ length: WALK_ROWS - LEG_TOP }, () =>
+    Array<string>(WALK_MASK_WIDTH).fill(' '),
+  );
+  for (const leg of LEGS) {
+    const t = (phase + leg.offset) % 1;
+    let paw: number;
+    let lift = 0;
+    if (t < STANCE_SHARE) {
+      // Planted: forward reach to full push-back, at constant speed.
+      paw = leg.anchor - STRIDE_SWEEP + 2 * STRIDE_SWEEP * (t / STANCE_SHARE);
+    } else {
+      // Swinging: back to front in the remaining slice, paw off the ground.
+      const s = (t - STANCE_SHARE) / (1 - STANCE_SHARE);
+      paw = leg.anchor + STRIDE_SWEEP - 2 * STRIDE_SWEEP * s;
+      lift = Math.sin(s * Math.PI) * 3;
+    }
+    const rows = legs.length;
+    const reach = Math.max(3, rows - Math.round(lift));
+    for (let r = 0; r < reach; r++) {
+      const x = Math.round(leg.anchor + (paw - leg.anchor) * ((r + 1) / rows));
+      for (let w = 0; w < leg.width; w++) {
+        const c = x + w;
+        if (c >= 0 && c < WALK_MASK_WIDTH) legs[r][c] = '#';
+      }
+      // The paw: one cell past the leading (left-facing) edge on the last row.
+      if (r === reach - 1 && x - 1 >= 0) legs[r][x - 1] = '#';
+    }
+  }
+  return [...WALK_BODY, ...legs.map((cells) => cells.join('').trimEnd())];
+}
+
+const WALK_MASKS_LEFT: readonly (readonly string[])[] = Array.from({ length: 8 }, (_, i) =>
+  buildWalkMask(i / 8),
+);
+
+/** Masks are pure '#' cells, so mirroring is an exact horizontal flip. */
+const mirrorMask = (mask: readonly string[]): readonly string[] =>
+  mask.map((row) => row.padEnd(WALK_MASK_WIDTH, ' ').split('').reverse().join('').trimEnd());
+
+export const WALK_MASKS: Readonly<Record<'left' | 'right', readonly (readonly string[])[]>> = {
+  left: WALK_MASKS_LEFT,
+  right: WALK_MASKS_LEFT.map(mirrorMask),
+};
+
+const SIT_WIDTH = Math.max(...SIT_MASK.map((row) => row.length));
+
+export const SIT_MASKS: Readonly<Record<'left' | 'right', readonly string[]>> = {
+  left: SIT_MASK,
+  right: SIT_MASK.map((row) => row.padEnd(SIT_WIDTH, ' ').split('').reverse().join('').trimEnd()),
+};
+
+/* ==========================================================================
+   Glyph fill - the reference renders' texture
+   ========================================================================== */
+
+/** The reference alphabet: heavy digits in the coat, light punctuation at
+    the edges, single wisps of fur just outside the silhouette. */
+const GLYPH_DENSE = '9988SS$5';
+const GLYPH_MID = '95o3s58o';
+const GLYPH_EDGE = ":;'.,`^";
+const GLYPH_WISP = ",'`.";
+
+/** Chance an interior cell renders as a gap - the felty holes in the coat. */
+const DROPOUT = 0.1;
+
+/** Chance a cell just outside the silhouette sprouts a fur wisp. */
+const WISP = 0.07;
 
 /**
- * Standing still: same body, legs straight under it, tail up. Shown for a
- * beat between sitting and walking (and again on arrival) so she rises,
- * walks, and settles - instead of teleporting between poses.
- */
-export const CAT_MASK_STAND: readonly string[] = [
-  ...WALK_BODY,
-  '       ######  #######        #######  ######',
-  '       #####    ######        ######    #####',
-  '       #####     #####        #####     #####',
-  '       ####      #####        #####      ####',
-  '       ####      ####         ####       ####',
-  '      #####      ####         ####      #####',
-];
-
-/**
- * Fill a walk mask with glyph noise. Edge cells (any blank neighbour) get the
- * light set; the interior mixes dense and mid weights, with occasional dropout
- * gaps - matching the reference's texture so sit and walk read as one cat.
+ * Fill a mask with glyph noise. Edge cells (any blank neighbour) get light
+ * punctuation, the interior mixes heavy and mid digits with occasional
+ * dropout, and empty cells hugging the silhouette occasionally sprout a
+ * wisp - so every re-roll shimmers like the reference's fur.
  */
 export function renderCat(mask: readonly string[], random: () => number): readonly string[] {
   const pick = (set: string) => set[Math.floor(random() * set.length)];
+  const at = (r: number, c: number) => mask[r]?.[c] === '#';
 
   return mask.map((row, r) => {
     let out = '';
-    for (let c = 0; c < row.length; c++) {
+    const width = Math.max(row.length, mask[r - 1]?.length ?? 0, mask[r + 1]?.length ?? 0);
+    for (let c = 0; c < width; c++) {
       if (row[c] !== '#') {
-        out += ' ';
+        const nearFur = at(r - 1, c) || at(r + 1, c) || at(r, c - 1) || at(r, c + 1);
+        out += nearFur && random() < WISP ? pick(GLYPH_WISP) : ' ';
         continue;
       }
       if (random() < DROPOUT) {
         out += ' ';
         continue;
       }
-      const edge =
-        (mask[r - 1]?.[c] ?? ' ') !== '#' ||
-        (mask[r + 1]?.[c] ?? ' ') !== '#' ||
-        (row[c - 1] ?? ' ') !== '#' ||
-        (row[c + 1] ?? ' ') !== '#';
+      const edge = !at(r - 1, c) || !at(r + 1, c) || !at(r, c - 1) || !at(r, c + 1);
       out += pick(edge ? GLYPH_EDGE : random() < 0.55 ? GLYPH_DENSE : GLYPH_MID);
     }
-    return out;
+    return out.trimEnd();
   });
 }
 
+/* ==========================================================================
+   Behaviour + motion tuning
+   ========================================================================== */
+
 /** Which behaviours the idle cat picks between, and how it weights them. */
 export interface IdleBehaviour {
-  readonly mode: 'sit' | 'flick' | 'sleep';
+  readonly mode: 'sit' | 'sleep';
   /** Relative likelihood of being chosen. */
   readonly weight: number;
   /** [min, max] seconds to hold the behaviour before wandering off again. */
@@ -164,28 +247,19 @@ export interface IdleBehaviour {
 }
 
 export const IDLE_BEHAVIOURS: readonly IdleBehaviour[] = [
-  { mode: 'sit', weight: 4, hold: [3, 6] },
-  { mode: 'flick', weight: 3, hold: [2, 4] },
+  { mode: 'sit', weight: 6, hold: [4, 9] },
   { mode: 'sleep', weight: 2, hold: [6, 11] },
 ];
 
 export const CAT_MOTION = {
-  /** Travel speed as a fraction of the floor's usable width, per second.
-      A cat this size prowls; she doesn't scamper. */
+  /** Travel speed as a fraction of the floor's width, per second.
+      A Maine Coon prowls: slow, heavy, elegant, calm. The leg cycle is keyed
+      to the distance this covers (WALK_CYCLE_COLS), not to a clock. */
   WALK_SPEED: 0.09,
-  /** Seconds per stride frame - legs extended <-> legs gathering. */
-  STEP_INTERVAL: 0.32,
-  /** Seconds between texture re-rolls while walking - the noise "crawls". */
-  SHIMMER_WALK: 0.16,
-  /** Seconds between tail-up / tail-down swaps during a flick. */
-  FLICK_INTERVAL: 0.55,
-  /** Height of the walking bob, in pixels. */
-  BOB_HEIGHT: 3,
-  /** Bob cycles per second while walking. */
-  BOB_RATE: 2.2,
+  /** Seconds between noise re-rolls while sitting - the fur breathing. */
+  SIT_SHIMMER: 0.9,
+  /** Height of the walking bob, in pixels. Subtle: the head stays level. */
+  BOB_HEIGHT: 2,
   /** Beat before the cat sets off toward a fresh spot. */
   ALERT_HOLD: 0.7,
-  /** How long the standing frame holds while she rises from (or settles into)
-      the sit - the beat that makes the transition read as getting up. */
-  RISE_HOLD: 0.38,
 } as const;

--- a/client/src/features/cat/cat-frames.ts
+++ b/client/src/features/cat/cat-frames.ts
@@ -1,0 +1,187 @@
+/**
+ * The cat. When she sits, she IS the reference art - transcribed verbatim,
+ * character by character, not approximated. Generation is reserved for what
+ * the reference doesn't have: the walking frames, whose glyph noise is rolled
+ * from the same alphabet so the two styles read as one animal.
+ */
+
+/**
+ * The reference, verbatim: a Maine Coon sitting in profile facing left, tail
+ * lying along the ground to the right with the tip curling up at the end.
+ */
+export const CAT_SIT_ART: readonly string[] = [
+  '3/              %',
+  ' G%          Rs',
+  ' @^%RK(^@@R3',
+  ' @#// ^^~%~/t(',
+  ' tC // sStt^~(',
+  '@@@@@@@@@R7 (s7',
+  '@t~%~R@Ct^(@(3Q',
+  '7~7R@^(e(/C%@C/^/#@',
+  '  @@C#SSs#@7//((%@',
+  ' KR@@@@S@C//%(@RsSG',
+  'QQQ@#eQt%%SRK@OO%G#KS',
+  'OSsO#RG%O#tR~@7tt%SsORS%',
+  ' OtKRSK3CS(Ot/(((CKt/%OsK(/t',
+  'tG@(eRK(/7~/t%7st~  /( (tCC^%',
+  ' 3O%O--^(~/t77OS~  (^^   ~(((/^t',
+  ' tt%t(%COt(C%t(  ^ //^   ^//~(sC/',
+  ' t%(tsQtt(Ss^^ ~ /~O(^      ^~%SQ',
+  '  es%%COK7^ /t7tOQ%3/     ^(((%SQK',
+  '  (SKS%3%~(#7COG(OOs / ^  /t%O3SQS',
+  '    SRKOS%3(%7sSOK(/~// ^(%OeGC3Q@Q',
+  '      (#RGCO%~t%eS  ((/(sCKt///t3Q@',
+  '       S CO~~S#sOe%ts%(t#%/^^/(t3e@',
+  '        KK^/teOK@@SOOt%t(///~/~tG%@@',
+  '         #O//7%S@G@@@%CS(///(t((SQs@@@      ^/t7eCt',
+  '         K/^~3R@@#%tKKC7/~//t%OQ%C@@@Rs3%/ t//~%%((C%(%st/',
+  '        S% /tS@@(tC3%(%t(7%eSQC%eQQR%O3t((tCC(t%Ot//(%%t// /(%/(',
+  '        s(^(s#@     /s@SCOOs@#C3(CR@ssKCC%O@Ct(t%OsO3SSOeSQRG%(t%t',
+  '       O//3CR@@    S( ~K@@@@@@R#@@@@ @@@R@@@@#@@@R@@@@@@@@@Q@G^ (CS%',
+  '      (~%StCs/       SKS                                %  ^/t%Gt',
+  '                                                          O tt#s%%',
+];
+
+/**
+ * The idle flick: same art, tail tip lifted off the ground for a beat. Only
+ * the last two rows differ from the reference - everything else stays exact.
+ */
+export const CAT_SIT_ART_FLICK: readonly string[] = [
+  ...CAT_SIT_ART.slice(0, 28),
+  '      (~%StCs/       SKS                                %  ^/t%GtO#s%',
+  '',
+];
+
+/** The reference's alphabet, split by visual weight - used by the walk frames. */
+const GLYPH_EDGE = '(/^~-t%s(',
+  GLYPH_MID = 'C3est7sKtO%',
+  GLYPH_DENSE = '@#RKQSGO';
+
+/** Chance any walk-frame cell renders as a gap - the "fur" holes. */
+const DROPOUT = 0.08;
+
+/**
+ * Mid-stride walking profile, facing left. A walking cat is LOW - about
+ * two-thirds of her sitting height - and long: level back, head carried at
+ * back height, deep belly, bushy tail curving up behind. Head width matches
+ * the sitting art's head, so the get-up reads as the same animal changing
+ * posture, not changing size. Two stride frames (legs extended / gathering)
+ * share this body, so only the legs move.
+ */
+const WALK_BODY: readonly string[] = [
+  '    ##   ##                                       ####',
+  '   ###########                                   #####',
+  '   ###########                                  #####',
+  '  ############                                 #####',
+  ' ##############                               ######',
+  ' ##############                              #####',
+  '  #############                             #####',
+  '   ##############                          #####',
+  '    #########################################',
+  '    ############################################',
+  '     ###########################################',
+  '     ##########################################',
+  '      ########################################',
+  '       ######################################',
+];
+
+export const CAT_MASK_WALK_A: readonly string[] = [
+  ...WALK_BODY,
+  '      ######   #######      #######   ######',
+  '     ######     ######      ######     #####',
+  '     #####       #####      #####       #####',
+  '    #####        ####       ####         ####',
+  '    ####         ####       ####          ####',
+  '   #####         ####       ####          #####',
+];
+
+export const CAT_MASK_WALK_B: readonly string[] = [
+  ...WALK_BODY,
+  '        ##### #######        ####### ######',
+  '        ####   ######        ######   #####',
+  '        ####    #####        #####    ####',
+  '        ####    #####        #####    ####',
+  '        ####    ####         ####     ####',
+  '       #####    ####         ####    #####',
+];
+
+/**
+ * Standing still: same body, legs straight under it, tail up. Shown for a
+ * beat between sitting and walking (and again on arrival) so she rises,
+ * walks, and settles - instead of teleporting between poses.
+ */
+export const CAT_MASK_STAND: readonly string[] = [
+  ...WALK_BODY,
+  '       ######  #######      #######  ######',
+  '       #####    ######      ######    #####',
+  '       #####     #####      #####     #####',
+  '       ####      #####      #####      ####',
+  '       ####      ####       ####       ####',
+  '      #####      ####       ####      #####',
+];
+
+/**
+ * Fill a walk mask with glyph noise. Edge cells (any blank neighbour) get the
+ * light set; the interior mixes dense and mid weights, with occasional dropout
+ * gaps - matching the reference's texture so sit and walk read as one cat.
+ */
+export function renderCat(mask: readonly string[], random: () => number): readonly string[] {
+  const pick = (set: string) => set[Math.floor(random() * set.length)];
+
+  return mask.map((row, r) => {
+    let out = '';
+    for (let c = 0; c < row.length; c++) {
+      if (row[c] !== '#') {
+        out += ' ';
+        continue;
+      }
+      if (random() < DROPOUT) {
+        out += ' ';
+        continue;
+      }
+      const edge =
+        (mask[r - 1]?.[c] ?? ' ') !== '#' ||
+        (mask[r + 1]?.[c] ?? ' ') !== '#' ||
+        (row[c - 1] ?? ' ') !== '#' ||
+        (row[c + 1] ?? ' ') !== '#';
+      out += pick(edge ? GLYPH_EDGE : random() < 0.55 ? GLYPH_DENSE : GLYPH_MID);
+    }
+    return out;
+  });
+}
+
+/** Which behaviours the idle cat picks between, and how it weights them. */
+export interface IdleBehaviour {
+  readonly mode: 'sit' | 'flick' | 'sleep';
+  /** Relative likelihood of being chosen. */
+  readonly weight: number;
+  /** [min, max] seconds to hold the behaviour before wandering off again. */
+  readonly hold: readonly [number, number];
+}
+
+export const IDLE_BEHAVIOURS: readonly IdleBehaviour[] = [
+  { mode: 'sit', weight: 4, hold: [3, 6] },
+  { mode: 'flick', weight: 3, hold: [2, 4] },
+  { mode: 'sleep', weight: 2, hold: [6, 11] },
+];
+
+export const CAT_MOTION = {
+  /** Travel speed as a fraction of the floor's usable width, per second.
+      A cat this size prowls; she doesn't scamper. */
+  WALK_SPEED: 0.09,
+  /** Seconds per stride frame - legs extended <-> legs gathering. */
+  STEP_INTERVAL: 0.32,
+  /** Seconds between texture re-rolls while walking - the noise "crawls". */
+  SHIMMER_WALK: 0.16,
+  /** Seconds between tail-up / tail-down swaps during a flick. */
+  FLICK_INTERVAL: 0.55,
+  /** Height of the walking bob, in pixels. */
+  BOB_HEIGHT: 3,
+  /** Bob cycles per second while walking. */
+  BOB_RATE: 2.2,
+  /** Beat before the cat sets off toward a fresh spot. */
+  ALERT_HOLD: 0.7,
+  /** How long the standing frame holds while she rises from (or settles into)
+      the sit - the beat that makes the transition read as getting up. */
+  RISE_HOLD: 0.38,
+} as const;

--- a/client/src/features/cat/cat-frames.ts
+++ b/client/src/features/cat/cat-frames.ts
@@ -61,48 +61,52 @@ const GLYPH_EDGE = '(/^~-t%s(',
 const DROPOUT = 0.08;
 
 /**
- * Mid-stride walking profile, facing left. A walking cat is LOW - about
- * two-thirds of her sitting height - and long: level back, head carried at
- * back height, deep belly, bushy tail curving up behind. Head width matches
- * the sitting art's head, so the get-up reads as the same animal changing
- * posture, not changing size. Two stride frames (legs extended / gathering)
- * share this body, so only the legs move.
+ * Mid-stride walking profile, facing left, modelled on the prowling reference:
+ * a walking cat is LOW - about two-thirds of her sitting height - and LONG,
+ * with a level back, head carried at back height, tall tufted ears, whisker
+ * wisps off the muzzle, a deep shaggy belly, and the signature Maine Coon tail:
+ * a fat plume raised behind her, nearly ear-high. Head width matches the
+ * sitting art's head, so the get-up reads as the same animal changing posture,
+ * not changing size. Two stride frames (legs extended / gathering) share this
+ * body, so only the legs move. The lone cells ahead of the muzzle render as
+ * light isolated glyphs - the whiskers.
  */
 const WALK_BODY: readonly string[] = [
-  '    ##   ##                                       ####',
-  '   ###########                                   #####',
-  '   ###########                                  #####',
-  '  ############                                 #####',
-  ' ##############                               ######',
-  ' ##############                              #####',
-  '  #############                             #####',
-  '   ##############                          #####',
-  '    #########################################',
-  '    ############################################',
-  '     ###########################################',
-  '     ##########################################',
+  '    ##   ##                                         #####',
+  '   ###   ###                                      ########',
+  '   ##########                                    #########',
+  '  ############                                  #########',
+  '  ############                                 ########',
+  '# #############                               ########',
+  ' ###############                              #######',
+  '# ###############                            #######',
+  '   ################                         #######',
+  '    ####################################### ######',
+  '    ##############################################',
+  '     #############################################',
+  '     ############################################',
+  '      ##########################################',
   '      ########################################',
-  '       ######################################',
 ];
 
 export const CAT_MASK_WALK_A: readonly string[] = [
   ...WALK_BODY,
-  '      ######   #######      #######   ######',
-  '     ######     ######      ######     #####',
-  '     #####       #####      #####       #####',
-  '    #####        ####       ####         ####',
-  '    ####         ####       ####          ####',
-  '   #####         ####       ####          #####',
+  '      ######   #######        #######   ######',
+  '     ######     ######        ######     #####',
+  '     #####       #####        #####       #####',
+  '    #####        ####         ####         ####',
+  '    ####         ####         ####          ####',
+  '   #####         ####         ####          #####',
 ];
 
 export const CAT_MASK_WALK_B: readonly string[] = [
   ...WALK_BODY,
-  '        ##### #######        ####### ######',
-  '        ####   ######        ######   #####',
-  '        ####    #####        #####    ####',
-  '        ####    #####        #####    ####',
-  '        ####    ####         ####     ####',
-  '       #####    ####         ####    #####',
+  '        ##### #######          ####### ######',
+  '        ####   ######          ######   #####',
+  '        ####    #####          #####    ####',
+  '        ####    #####          #####    ####',
+  '        ####    ####           ####     ####',
+  '       #####    ####           ####    #####',
 ];
 
 /**
@@ -112,12 +116,12 @@ export const CAT_MASK_WALK_B: readonly string[] = [
  */
 export const CAT_MASK_STAND: readonly string[] = [
   ...WALK_BODY,
-  '       ######  #######      #######  ######',
-  '       #####    ######      ######    #####',
-  '       #####     #####      #####     #####',
-  '       ####      #####      #####      ####',
-  '       ####      ####       ####       ####',
-  '      #####      ####       ####      #####',
+  '       ######  #######        #######  ######',
+  '       #####    ######        ######    #####',
+  '       #####     #####        #####     #####',
+  '       ####      #####        #####      ####',
+  '       ####      ####         ####       ####',
+  '      #####      ####         ####      #####',
 ];
 
 /**

--- a/client/src/features/cat/cat-playground.module.css
+++ b/client/src/features/cat/cat-playground.module.css
@@ -1,0 +1,246 @@
+/* ==========================================================================
+   /cat - BEM Methodology
+   The site's one unserious page. Same monochrome mono language as the 404 maze
+   and the console SDK; a character-art cat wanders a floor and does cat things.
+   ========================================================================== */
+
+/* Block: cat */
+.cat {
+  min-height: 100vh;
+  background-color: var(--color-neutral-950);
+  color: var(--color-neutral-100);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+
+/* The same soft radial bloom the 404 and hero use, for figure-ground depth. */
+.cat::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(900px, 92%);
+  height: 620px;
+  background: radial-gradient(
+    ellipse at center,
+    color-mix(in srgb, var(--color-primary-400) 6%, transparent) 0%,
+    transparent 62%
+  );
+  pointer-events: none;
+  z-index: var(--z-index-base);
+}
+
+/* The VK mark: the one bit of site chrome, and the quiet way home. */
+.cat__home-mark {
+  position: absolute;
+  top: var(--spacing-6);
+  left: var(--spacing-6);
+  z-index: 2;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.04em;
+  color: var(--color-foreground);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+.cat__home-mark:hover {
+  color: var(--color-primary-400);
+}
+
+.cat__home-mark:focus-visible {
+  outline: var(--outline-width) solid var(--color-primary-400);
+  outline-offset: var(--outline-offset);
+}
+
+.cat__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-8);
+  padding: var(--spacing-20) var(--spacing-6);
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: var(--content-max-width-md);
+  margin: 0 auto;
+}
+
+.cat__intro {
+  text-align: center;
+  max-width: 46ch;
+}
+
+.cat__kicker {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  color: var(--color-label-muted);
+  margin: 0 0 var(--spacing-4);
+}
+
+.cat__title {
+  font-family: var(--font-family-mono);
+  font-size: clamp(var(--font-size-2xl), 5vw, var(--font-size-4xl));
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-foreground);
+  margin: 0 0 var(--spacing-4);
+}
+
+.cat__lead {
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-lg);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-neutral-300);
+  margin: 0;
+}
+
+/* The stage the cat walks on. Its children are all absolutely positioned, so
+   it has no content width; align-self:stretch fills the centred column's cross
+   axis (align-items:center on the parent would otherwise collapse it to 0). */
+.cat__floor {
+  position: relative;
+  align-self: stretch;
+  width: 100%;
+  height: 440px;
+  cursor: pointer;
+}
+
+/* The cat itself: a glyph-noise silhouette (24 rows of dense character art),
+   anchored by its haunches to the floor line. The platform monospace keeps the
+   texture grid tight (same reasoning as the maze). */
+.cat__sprite {
+  position: absolute;
+  left: 0;
+  /* Paw row rests directly on the floor line (line sits at bottom: 24px) */
+  bottom: 25px;
+  margin: 0;
+  font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-size: clamp(0.44rem, 1.5vw, 0.82rem);
+  line-height: 1.05;
+  letter-spacing: 0;
+  white-space: pre;
+  color: var(--color-neutral-100);
+  text-shadow: 0 0 14px color-mix(in srgb, var(--color-primary-400) 18%, transparent);
+  user-select: none;
+  will-change: transform;
+  transition: opacity 0.8s ease;
+}
+
+/* Asleep: the whole texture dims, like fur in shadow. */
+.cat__sprite--sleeping {
+  opacity: 0.7;
+}
+
+/* Facing wrapper: the loop flips this (scaleX) when she walks right, so the
+   zzz above never renders mirrored. */
+.cat__art {
+  display: block;
+  transform-origin: center;
+}
+
+/* Floating "z z z" for the sleeping pose, drifting up from the head. Lives
+   inside the facing wrapper so it stays over the head whichever way she faces;
+   the scaleX(var) counter-flips the glyphs so the z's never mirror. The drift
+   uses the standalone `translate` property so it can't fight the transform. */
+.cat__zzz {
+  position: absolute;
+  top: -1.4em;
+  left: 8%;
+  font-size: 1.6em;
+  letter-spacing: 0.1em;
+  color: var(--color-primary-400);
+  opacity: 0.85;
+  transform: scaleX(var(--cat-facing, 1));
+  animation: catDrift 2.4s ease-in-out infinite;
+}
+
+@keyframes catDrift {
+  0%,
+  100% {
+    translate: 0 0;
+    opacity: 0.4;
+  }
+  50% {
+    translate: 0 -6px;
+    opacity: 0.9;
+  }
+}
+
+/* The ground: a single dim rule, like a terminal baseline. */
+.cat__floor-line {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 24px;
+  height: var(--border-width-thin);
+  background: linear-gradient(
+    to right,
+    transparent,
+    color-mix(in srgb, var(--color-neutral-300) 28%, transparent) 15%,
+    color-mix(in srgb, var(--color-neutral-300) 28%, transparent) 85%,
+    transparent
+  );
+}
+
+/* Comment-register hint, matching approach.sh / the maze notes. */
+.cat__hint {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  color: hsl(42, 12%, 41%);
+  margin: 0;
+  text-align: center;
+}
+
+.cat__back {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--color-foreground);
+  text-decoration: none;
+  padding: 0.875rem 1.75rem;
+  border: var(--border-width-thin) solid var(--color-border);
+  border-radius: 0;
+  transition:
+    background 0.2s ease-in-out,
+    border-color 0.2s ease-in-out;
+}
+
+.cat__back:hover {
+  background: color-mix(in srgb, var(--color-primary-400) 6%, transparent);
+  border-color: color-mix(in srgb, var(--color-primary-400) 50%, transparent);
+}
+
+.cat__back:focus-visible {
+  outline: var(--outline-width) solid var(--color-primary-400);
+  outline-offset: var(--outline-offset);
+}
+
+/* Reduced motion: the cat just sits, centred and still. No wandering, no bob,
+   no drifting Zzz. The rAF loop is skipped entirely in the component. */
+@media (prefers-reduced-motion: reduce) {
+  .cat__sprite {
+    left: 50%;
+    transform: translateX(-50%) !important;
+  }
+
+  .cat__zzz {
+    animation: none;
+  }
+
+  .cat__floor {
+    cursor: default;
+  }
+}

--- a/client/src/features/cat/cat-playground.module.css
+++ b/client/src/features/cat/cat-playground.module.css
@@ -77,16 +77,6 @@
   max-width: 46ch;
 }
 
-.cat__kicker {
-  font-family: var(--font-family-mono);
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-semibold);
-  text-transform: uppercase;
-  letter-spacing: 0.32em;
-  color: var(--color-label-muted);
-  margin: 0 0 var(--spacing-4);
-}
-
 .cat__title {
   font-family: var(--font-family-mono);
   font-size: clamp(var(--font-size-2xl), 5vw, var(--font-size-4xl));
@@ -116,10 +106,10 @@
   cursor: pointer;
 }
 
-/* The cat itself: the sitting reference is 30 rows of glyph art; walking is a
-   lower 20-row prowl. Kept small so she reads as a real pet on the floor - and
-   so the ~1/3 height drop from sit to walk is a gentle settle, not a lurch.
-   The platform monospace keeps the texture grid tight (same as the maze). */
+/* The cat itself: dense glyph-noise texture over silhouette masks, matching
+   the reference renders - 92 columns wide with the plume tail, 40 rows
+   walking, 44 sitting. Tiny glyphs so the noise fuses into fur at arm's
+   length. The platform monospace keeps the texture grid tight. */
 .cat__sprite {
   position: absolute;
   left: 0;
@@ -127,7 +117,7 @@
   bottom: 25px;
   margin: 0;
   font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, 'Liberation Mono', monospace;
-  font-size: clamp(0.28rem, 0.95vw, 0.52rem);
+  font-size: clamp(0.2rem, 0.68vw, 0.38rem);
   line-height: 1.05;
   letter-spacing: 0;
   white-space: pre;
@@ -135,15 +125,17 @@
   text-shadow: 0 0 14px color-mix(in srgb, var(--color-primary-400) 18%, transparent);
   user-select: none;
   will-change: transform;
-  transition: opacity 0.8s ease;
+  /* font-size eases the seated <-> standing scale change so pose swaps
+     read as posture changes, not jump cuts. */
+  transition:
+    opacity 0.8s ease,
+    font-size 0.45s ease;
 }
 
-/* Seated: the reference art is 30 rows to the walk's 21, so at equal font
-   sizes she'd tower over her own prowl and every get-up would read as a
-   collapse. A smaller seated glyph brings her sitting height to just a touch
-   above her walking height - the transition becomes a posture change. */
+/* Seated: the sitting mask is 44 rows to the walk's 40; a slightly smaller
+   seated glyph keeps her apparent height steady across the pose swap. */
 .cat__sprite--seated {
-  font-size: clamp(0.21rem, 0.72vw, 0.4rem);
+  font-size: clamp(0.18rem, 0.62vw, 0.35rem);
 }
 
 /* Asleep: the whole texture dims, like fur in shadow. */
@@ -151,26 +143,24 @@
   opacity: 0.7;
 }
 
-/* Facing wrapper: the loop flips this (scaleX) when she walks right, so the
-   zzz above never renders mirrored. */
+/* Art wrapper: each facing has its own frame set now, so nothing flips -
+   this just anchors the zzz over the art. */
 .cat__art {
   display: block;
-  transform-origin: center;
 }
 
-/* Floating "z z z" for the sleeping pose, drifting up from the head. Lives
-   inside the facing wrapper so it stays over the head whichever way she faces;
-   the scaleX(var) counter-flips the glyphs so the z's never mirror. The drift
-   uses the standalone `translate` property so it can't fight the transform. */
+/* Floating "z z z" for the sleeping pose, drifting up from the cat. The
+   drift uses the standalone `translate` property so it can't fight any
+   transform. She sleeps in profile; the zzz rises from mid-body so it works
+   whichever way she faces. */
 .cat__zzz {
   position: absolute;
   top: -1.4em;
-  left: 8%;
+  left: 40%;
   font-size: 1.6em;
   letter-spacing: 0.1em;
   color: var(--color-primary-400);
   opacity: 0.85;
-  transform: scaleX(var(--cat-facing, 1));
   animation: catDrift 2.4s ease-in-out infinite;
 }
 

--- a/client/src/features/cat/cat-playground.module.css
+++ b/client/src/features/cat/cat-playground.module.css
@@ -112,13 +112,14 @@
   position: relative;
   align-self: stretch;
   width: 100%;
-  height: 440px;
+  height: 300px;
   cursor: pointer;
 }
 
-/* The cat itself: a glyph-noise silhouette (24 rows of dense character art),
-   anchored by its haunches to the floor line. The platform monospace keeps the
-   texture grid tight (same reasoning as the maze). */
+/* The cat itself: the sitting reference is 30 rows of glyph art; walking is a
+   lower 20-row prowl. Kept small so she reads as a real pet on the floor - and
+   so the ~1/3 height drop from sit to walk is a gentle settle, not a lurch.
+   The platform monospace keeps the texture grid tight (same as the maze). */
 .cat__sprite {
   position: absolute;
   left: 0;
@@ -126,7 +127,7 @@
   bottom: 25px;
   margin: 0;
   font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, 'Liberation Mono', monospace;
-  font-size: clamp(0.44rem, 1.5vw, 0.82rem);
+  font-size: clamp(0.28rem, 0.95vw, 0.52rem);
   line-height: 1.05;
   letter-spacing: 0;
   white-space: pre;
@@ -135,6 +136,14 @@
   user-select: none;
   will-change: transform;
   transition: opacity 0.8s ease;
+}
+
+/* Seated: the reference art is 30 rows to the walk's 21, so at equal font
+   sizes she'd tower over her own prowl and every get-up would read as a
+   collapse. A smaller seated glyph brings her sitting height to just a touch
+   above her walking height - the transition becomes a posture change. */
+.cat__sprite--seated {
+  font-size: clamp(0.21rem, 0.72vw, 0.4rem);
 }
 
 /* Asleep: the whole texture dims, like fur in shadow. */

--- a/client/src/features/cat/cat-playground.tsx
+++ b/client/src/features/cat/cat-playground.tsx
@@ -49,6 +49,9 @@ export default function CatPlayground() {
   // She enters (and, under reduced motion, stays) as the reference: sitting.
   const [art, setArt] = useState<readonly string[]>(CAT_SIT_ART);
   const [sleeping, setSleeping] = useState(false);
+  // The seated reference renders a notch smaller than the walk frames, so the
+  // get-up reads as a posture change rather than a size drop.
+  const seated = art === CAT_SIT_ART || art === CAT_SIT_ART_FLICK;
 
   const floorRef = useRef<HTMLDivElement>(null);
   const catRef = useRef<HTMLPreElement>(null);
@@ -99,6 +102,7 @@ export default function CatPlayground() {
     let facing = 1; // 1 = the art's native left-facing; -1 = mirrored
     let currentSleeping = false;
     let artKey = 'sit'; // which frame is currently committed to React
+    let widestPx = 0; // widest sprite seen so far, across all poses
     const start = performance.now();
 
     // Commit a frame only when it actually changes. Sitting frames are the
@@ -144,10 +148,11 @@ export default function CatPlayground() {
       const cat = stateRef.current;
       const width = floorWidth();
 
-      // While the sit art (the widest frame) is showing, refresh the range it
-      // defines. Survives resizes: she sits often, so the measure stays fresh.
-      if (artKey === 'sit' && catRef.current && width > 0) {
-        maxFracRef.current = Math.max(0.05, (width - catRef.current.offsetWidth) / width);
+      // Track the widest frame we've seen (poses render at different sizes)
+      // so the roaming range always fits her fully, whichever pose she's in.
+      if (catRef.current && width > 0) {
+        widestPx = Math.max(widestPx, catRef.current.offsetWidth);
+        maxFracRef.current = Math.max(0.05, (width - widestPx) / width);
       }
 
       // --- advance the state machine ---
@@ -289,7 +294,13 @@ export default function CatPlayground() {
         >
           <pre
             ref={catRef}
-            className={`${styles['cat__sprite']}${sleeping ? ` ${styles['cat__sprite--sleeping']}` : ''}`}
+            className={[
+              styles['cat__sprite'],
+              seated ? styles['cat__sprite--seated'] : '',
+              sleeping ? styles['cat__sprite--sleeping'] : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
             aria-hidden="true"
           >
             <span ref={artRef} className={styles['cat__art']}>

--- a/client/src/features/cat/cat-playground.tsx
+++ b/client/src/features/cat/cat-playground.tsx
@@ -1,0 +1,311 @@
+import { useCallback, useEffect, useRef, useState, type PointerEvent } from 'react';
+import { motion } from 'motion/react';
+import { PERSONAL_INFO, CAT } from '@/shared/constants/strings';
+import { ANIMATION_DURATION, INITIAL_OFFSET, OPACITY } from '@/shared/constants/layout';
+import {
+  CAT_SIT_ART,
+  CAT_SIT_ART_FLICK,
+  CAT_MASK_WALK_A,
+  CAT_MASK_WALK_B,
+  CAT_MASK_STAND,
+  renderCat,
+  IDLE_BEHAVIOURS,
+  CAT_MOTION,
+  type IdleBehaviour,
+} from './cat-frames';
+import styles from './cat-playground.module.css';
+
+type Mode = 'walk' | 'sit' | 'flick' | 'sleep' | 'alert' | 'rise' | 'settle';
+
+interface CatState {
+  mode: Mode;
+  /** Horizontal position as a fraction [0,1] of the floor's usable width. */
+  x: number;
+  /** Where the cat is walking to (fraction). */
+  targetX: number;
+  /** Timestamp (seconds) at which the current non-walk behaviour ends. */
+  until: number;
+}
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+const rand = (min: number, max: number) => min + Math.random() * (max - min);
+
+/** Pick the next idle behaviour by weight. */
+function pickIdle(): IdleBehaviour {
+  const total = IDLE_BEHAVIOURS.reduce((sum, b) => sum + b.weight, 0);
+  let roll = Math.random() * total;
+  for (const behaviour of IDLE_BEHAVIOURS) {
+    roll -= behaviour.weight;
+    if (roll <= 0) return behaviour;
+  }
+  return IDLE_BEHAVIOURS[0];
+}
+
+export default function CatPlayground() {
+  // The current art frame + a "sleeping" flag are the only things that trigger
+  // re-renders; position/facing are written straight to the DOM in the loop.
+  // She enters (and, under reduced motion, stays) as the reference: sitting.
+  const [art, setArt] = useState<readonly string[]>(CAT_SIT_ART);
+  const [sleeping, setSleeping] = useState(false);
+
+  const floorRef = useRef<HTMLDivElement>(null);
+  const catRef = useRef<HTMLPreElement>(null);
+  const artRef = useRef<HTMLSpanElement>(null);
+  const stateRef = useRef<CatState>({ mode: 'sit', x: 0.4, targetX: 0.4, until: 0 });
+  const reducedRef = useRef(false);
+  // Rightmost reachable x (fraction of floor width), measured against the
+  // WIDEST frame - the sit art - so no pose swap ever changes her range.
+  const maxFracRef = useRef(0.4);
+
+  // Send the cat to a spot the visitor clicked. She notices (alert), then heads over.
+  const callTo = useCallback((fraction: number) => {
+    if (reducedRef.current) return;
+    const cat = stateRef.current;
+    cat.targetX = Math.min(maxFracRef.current, Math.max(0.02, fraction));
+    cat.mode = 'alert';
+    cat.until = 0; // set on the next tick, once we have `now`
+  }, []);
+
+  const onFloorPointerDown = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      const floor = floorRef.current;
+      if (!floor) return;
+      const rect = floor.getBoundingClientRect();
+      callTo((event.clientX - rect.left) / rect.width);
+    },
+    [callTo],
+  );
+
+  useEffect(() => {
+    const previous = document.title;
+    document.title = CAT.DOC_TITLE;
+    return () => {
+      document.title = previous;
+    };
+  }, []);
+
+  useEffect(() => {
+    console.log(`%c${CAT.CONSOLE_LINE}`, 'color:#8a8578;font-style:italic;');
+  }, []);
+
+  useEffect(() => {
+    reducedRef.current = prefersReducedMotion();
+    // Reduced motion: one still render, no loop, no travel, no shimmer.
+    if (reducedRef.current) return;
+
+    let raf = 0;
+    let facing = 1; // 1 = the art's native left-facing; -1 = mirrored
+    let currentSleeping = false;
+    let artKey = 'sit'; // which frame is currently committed to React
+    const start = performance.now();
+
+    // Commit a frame only when it actually changes. Sitting frames are the
+    // exact reference art (fixed keys); walk frames are keyed by time bucket
+    // so the noise re-rolls as she moves. The frame is built lazily - a key
+    // that hasn't changed costs nothing.
+    const show = (key: string, make: () => readonly string[]) => {
+      if (key === artKey) return;
+      artKey = key;
+      setArt(make());
+    };
+
+    // x is a fraction of the FLOOR width - not of (floor - sprite) - because
+    // the sprite's width changes between poses (the sit art is wider than the
+    // walk frames). Anchoring to a constant keeps her planted through every
+    // frame swap; only the right-edge clamp ever references the sprite width.
+    const floorWidth = () => floorRef.current?.clientWidth ?? 0;
+    const maxLeft = () => {
+      const floor = floorRef.current;
+      const cat = catRef.current;
+      if (!floor || !cat) return 0;
+      return Math.max(0, floor.clientWidth - cat.offsetWidth);
+    };
+
+    const beginWander = (cat: CatState, now: number) => {
+      // New destination, anywhere she can fully fit.
+      const next = rand(0.02, Math.max(0.05, maxFracRef.current));
+      // Only bother walking if it's a meaningful distance; otherwise idle again.
+      if (Math.abs(next - cat.x) < 0.08) {
+        const idle = pickIdle();
+        cat.mode = idle.mode;
+        cat.until = now + rand(idle.hold[0], idle.hold[1]);
+      } else {
+        // Stand up first; the walk starts when the rise beat ends.
+        cat.targetX = next;
+        cat.mode = 'rise';
+        cat.until = now + CAT_MOTION.RISE_HOLD;
+      }
+    };
+
+    const tick = (nowMs: number) => {
+      const now = (nowMs - start) / 1000;
+      const cat = stateRef.current;
+      const width = floorWidth();
+
+      // While the sit art (the widest frame) is showing, refresh the range it
+      // defines. Survives resizes: she sits often, so the measure stays fresh.
+      if (artKey === 'sit' && catRef.current && width > 0) {
+        maxFracRef.current = Math.max(0.05, (width - catRef.current.offsetWidth) / width);
+      }
+
+      // --- advance the state machine ---
+      // Getting up and settling down both pass through the standing beat, so
+      // sit -> walk is: notice, rise, walk, stand, sit - never a jump cut.
+      if (cat.mode === 'alert') {
+        if (cat.until === 0) cat.until = now + CAT_MOTION.ALERT_HOLD;
+        if (now >= cat.until) {
+          cat.mode = 'rise';
+          cat.until = now + CAT_MOTION.RISE_HOLD;
+        }
+      } else if (cat.mode === 'rise') {
+        if (now >= cat.until) cat.mode = 'walk';
+      } else if (cat.mode === 'walk') {
+        const dir = Math.sign(cat.targetX - cat.x) || 1;
+        facing = dir > 0 ? -1 : 1; // the art faces left; mirror when heading right
+        cat.x += dir * CAT_MOTION.WALK_SPEED * 0.016;
+        if ((dir > 0 && cat.x >= cat.targetX) || (dir < 0 && cat.x <= cat.targetX)) {
+          cat.x = cat.targetX;
+          cat.mode = 'settle';
+          cat.until = now + CAT_MOTION.RISE_HOLD;
+        }
+      } else if (cat.mode === 'settle') {
+        if (now >= cat.until) {
+          const idle = pickIdle();
+          cat.mode = idle.mode;
+          cat.until = now + rand(idle.hold[0], idle.hold[1]);
+        }
+      } else if (now >= cat.until) {
+        beginWander(cat, now);
+      }
+
+      // --- texture, bob, and sleep flag for the current mode ---
+      let bob = 0;
+      let isSleeping = false;
+
+      switch (cat.mode) {
+        case 'walk': {
+          // A real gait: two stride silhouettes (legs extended <-> gathering)
+          // swap on the step beat, and the noise re-rolls between swaps so the
+          // texture crawls like fur catching light.
+          const stride = Math.floor(now / CAT_MOTION.STEP_INTERVAL) % 2;
+          const bucket = Math.floor(now / CAT_MOTION.SHIMMER_WALK);
+          show(`walk-${bucket}`, () =>
+            renderCat(stride === 0 ? CAT_MASK_WALK_A : CAT_MASK_WALK_B, Math.random),
+          );
+          bob = -Math.abs(Math.sin(now * Math.PI * CAT_MOTION.BOB_RATE)) * CAT_MOTION.BOB_HEIGHT;
+          break;
+        }
+        case 'rise':
+          // Up on all fours, already turned toward where she's headed.
+          facing = Math.sign(cat.targetX - cat.x) > 0 ? -1 : 1;
+          show('stand', () => renderCat(CAT_MASK_STAND, Math.random));
+          break;
+        case 'settle':
+          // Standing beat again on arrival; she turns back to the reference
+          // orientation here, where flipping the noise is imperceptible.
+          facing = 1;
+          show('stand', () => renderCat(CAT_MASK_STAND, Math.random));
+          break;
+        case 'flick': {
+          // Tail tip up, tail tip down - the reference art, wiggling only its
+          // last two rows on a slow beat.
+          const phase = Math.floor(now / CAT_MOTION.FLICK_INTERVAL) % 2;
+          facing = 1;
+          show(phase === 0 ? 'flick' : 'sit', () =>
+            phase === 0 ? CAT_SIT_ART_FLICK : CAT_SIT_ART,
+          );
+          break;
+        }
+        case 'sleep':
+          // Perfectly still; the drifting zzz does the animating.
+          facing = 1;
+          show('sit', () => CAT_SIT_ART);
+          isSleeping = true;
+          break;
+        case 'alert':
+          // The tail-tip lift is the twitch of noticing.
+          facing = 1;
+          show('flick', () => CAT_SIT_ART_FLICK);
+          break;
+        case 'sit':
+        default:
+          // Exactly the reference: same glyphs, same orientation. However she
+          // arrived, she turns to settle the way the art was drawn.
+          facing = 1;
+          show('sit', () => CAT_SIT_ART);
+          break;
+      }
+
+      // --- paint position + facing (cheap: no React involved) ---
+      // Facing flips the inner art wrapper, not the sprite itself, so the
+      // floating "zzz" never renders mirrored.
+      if (catRef.current && width > 0) {
+        const px = Math.min(cat.x * width, maxLeft());
+        catRef.current.style.transform = `translate3d(${px}px, ${bob}px, 0)`;
+      }
+      if (artRef.current) {
+        artRef.current.style.transform = `scaleX(${facing})`;
+        // The zzz counter-flips against this so its glyphs never mirror.
+        artRef.current.style.setProperty('--cat-facing', String(facing));
+      }
+
+      if (isSleeping !== currentSleeping) {
+        currentSleeping = isSleeping;
+        setSleeping(isSleeping);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return (
+    <div className={styles['cat']}>
+      <a className={styles['cat__home-mark']} href="/" aria-label="Back to home">
+        {PERSONAL_INFO.INITIALS}
+      </a>
+
+      <motion.main
+        className={styles['cat__main']}
+        initial={{ opacity: OPACITY.HIDDEN, y: INITIAL_OFFSET.Y_SMALL }}
+        animate={{ opacity: OPACITY.VISIBLE, y: 0 }}
+        transition={{ duration: ANIMATION_DURATION.NORMAL }}
+      >
+        <header className={styles['cat__intro']}>
+          <p className={styles['cat__kicker']}>{CAT.KICKER}</p>
+          <h1 className={styles['cat__title']}>{CAT.TITLE_MAIN}</h1>
+          <p className={styles['cat__lead']}>{CAT.LEAD}</p>
+        </header>
+
+        {/* The stage: click anywhere on the floor and the cat comes over. */}
+        <div
+          ref={floorRef}
+          className={styles['cat__floor']}
+          onPointerDown={onFloorPointerDown}
+          role="presentation"
+        >
+          <pre
+            ref={catRef}
+            className={`${styles['cat__sprite']}${sleeping ? ` ${styles['cat__sprite--sleeping']}` : ''}`}
+            aria-hidden="true"
+          >
+            <span ref={artRef} className={styles['cat__art']}>
+              {sleeping && <span className={styles['cat__zzz']}>z&#8202;z&#8202;z</span>}
+              {art.join('\n')}
+            </span>
+          </pre>
+          <div className={styles['cat__floor-line']} aria-hidden="true" />
+        </div>
+
+        <p className={styles['cat__hint']}>{CAT.HINT}</p>
+
+        <a className={styles['cat__back']} href="/">
+          ← {CAT.BACK_ACTION}
+        </a>
+      </motion.main>
+    </div>
+  );
+}

--- a/client/src/features/cat/cat-playground.tsx
+++ b/client/src/features/cat/cat-playground.tsx
@@ -3,11 +3,10 @@ import { motion } from 'motion/react';
 import { PERSONAL_INFO, CAT } from '@/shared/constants/strings';
 import { ANIMATION_DURATION, INITIAL_OFFSET, OPACITY } from '@/shared/constants/layout';
 import {
-  CAT_SIT_ART,
-  CAT_SIT_ART_FLICK,
-  CAT_MASK_WALK_A,
-  CAT_MASK_WALK_B,
-  CAT_MASK_STAND,
+  SIT_MASKS,
+  WALK_MASKS,
+  WALK_MASK_WIDTH,
+  WALK_CYCLE_COLS,
   renderCat,
   IDLE_BEHAVIOURS,
   CAT_MOTION,
@@ -15,11 +14,12 @@ import {
 } from './cat-frames';
 import styles from './cat-playground.module.css';
 
-type Mode = 'walk' | 'sit' | 'flick' | 'sleep' | 'alert' | 'rise' | 'settle';
+type Mode = 'walk' | 'sit' | 'sleep' | 'alert';
+type Facing = 'left' | 'right';
 
 interface CatState {
   mode: Mode;
-  /** Horizontal position as a fraction [0,1] of the floor's usable width. */
+  /** Horizontal position as a fraction [0,1] of the floor's width. */
   x: number;
   /** Where the cat is walking to (fraction). */
   targetX: number;
@@ -44,22 +44,21 @@ function pickIdle(): IdleBehaviour {
 }
 
 export default function CatPlayground() {
-  // The current art frame + a "sleeping" flag are the only things that trigger
+  // The current art + a "sleeping" flag are the only things that trigger
   // re-renders; position/facing are written straight to the DOM in the loop.
-  // She enters (and, under reduced motion, stays) as the reference: sitting.
-  const [art, setArt] = useState<readonly string[]>(CAT_SIT_ART);
+  // She enters (and, under reduced motion, stays) sitting, facing left.
+  const [art, setArt] = useState<readonly string[]>(() => renderCat(SIT_MASKS.left, Math.random));
   const [sleeping, setSleeping] = useState(false);
-  // The seated reference renders a notch smaller than the walk frames, so the
-  // get-up reads as a posture change rather than a size drop.
-  const seated = art === CAT_SIT_ART || art === CAT_SIT_ART_FLICK;
+  // Sitting masks are 44 rows to the walk's 40; the seated pose renders a
+  // notch smaller (see the CSS) so her apparent height barely changes.
+  const seated = art.length === SIT_MASKS.left.length;
 
   const floorRef = useRef<HTMLDivElement>(null);
   const catRef = useRef<HTMLPreElement>(null);
-  const artRef = useRef<HTMLSpanElement>(null);
   const stateRef = useRef<CatState>({ mode: 'sit', x: 0.4, targetX: 0.4, until: 0 });
   const reducedRef = useRef(false);
   // Rightmost reachable x (fraction of floor width), measured against the
-  // WIDEST frame - the sit art - so no pose swap ever changes her range.
+  // widest frame seen so far, so no pose swap ever changes her range.
   const maxFracRef = useRef(0.4);
 
   // Send the cat to a spot the visitor clicked. She notices (alert), then heads over.
@@ -99,26 +98,25 @@ export default function CatPlayground() {
     if (reducedRef.current) return;
 
     let raf = 0;
-    let facing = 1; // 1 = the art's native left-facing; -1 = mirrored
+    let facing: Facing = 'left'; // she keeps facing her last direction of travel
+    let walkPx = 0; // ground covered while walking, in pixels (cumulative)
     let currentSleeping = false;
-    let artKey = 'sit'; // which frame is currently committed to React
+    let artKey = 'init'; // which frame is currently committed to React
     let widestPx = 0; // widest sprite seen so far, across all poses
     const start = performance.now();
 
-    // Commit a frame only when it actually changes. Sitting frames are the
-    // exact reference art (fixed keys); walk frames are keyed by time bucket
-    // so the noise re-rolls as she moves. The frame is built lazily - a key
-    // that hasn't changed costs nothing.
-    const show = (key: string, make: () => readonly string[]) => {
+    // Commit a frame only when its key changes. Every commit re-rolls the
+    // glyph noise, so motion (and the idle shimmer) ripples through the fur.
+    const show = (key: string, mask: readonly string[]) => {
       if (key === artKey) return;
       artKey = key;
-      setArt(make());
+      setArt(renderCat(mask, Math.random));
     };
 
     // x is a fraction of the FLOOR width - not of (floor - sprite) - because
-    // the sprite's width changes between poses (the sit art is wider than the
-    // walk frames). Anchoring to a constant keeps her planted through every
-    // frame swap; only the right-edge clamp ever references the sprite width.
+    // the sprite's width changes between poses. Anchoring to a constant keeps
+    // her planted through every frame swap; only the right-edge clamp ever
+    // references the sprite width.
     const floorWidth = () => floorRef.current?.clientWidth ?? 0;
     const maxLeft = () => {
       const floor = floorRef.current;
@@ -136,10 +134,8 @@ export default function CatPlayground() {
         cat.mode = idle.mode;
         cat.until = now + rand(idle.hold[0], idle.hold[1]);
       } else {
-        // Stand up first; the walk starts when the rise beat ends.
         cat.targetX = next;
-        cat.mode = 'rise';
-        cat.until = now + CAT_MOTION.RISE_HOLD;
+        cat.mode = 'walk';
       }
     };
 
@@ -156,27 +152,15 @@ export default function CatPlayground() {
       }
 
       // --- advance the state machine ---
-      // Getting up and settling down both pass through the standing beat, so
-      // sit -> walk is: notice, rise, walk, stand, sit - never a jump cut.
       if (cat.mode === 'alert') {
         if (cat.until === 0) cat.until = now + CAT_MOTION.ALERT_HOLD;
-        if (now >= cat.until) {
-          cat.mode = 'rise';
-          cat.until = now + CAT_MOTION.RISE_HOLD;
-        }
-      } else if (cat.mode === 'rise') {
         if (now >= cat.until) cat.mode = 'walk';
       } else if (cat.mode === 'walk') {
         const dir = Math.sign(cat.targetX - cat.x) || 1;
-        facing = dir > 0 ? -1 : 1; // the art faces left; mirror when heading right
+        facing = dir > 0 ? 'right' : 'left';
         cat.x += dir * CAT_MOTION.WALK_SPEED * 0.016;
         if ((dir > 0 && cat.x >= cat.targetX) || (dir < 0 && cat.x <= cat.targetX)) {
           cat.x = cat.targetX;
-          cat.mode = 'settle';
-          cat.until = now + CAT_MOTION.RISE_HOLD;
-        }
-      } else if (cat.mode === 'settle') {
-        if (now >= cat.until) {
           const idle = pickIdle();
           cat.mode = idle.mode;
           cat.until = now + rand(idle.hold[0], idle.hold[1]);
@@ -185,75 +169,49 @@ export default function CatPlayground() {
         beginWander(cat, now);
       }
 
-      // --- texture, bob, and sleep flag for the current mode ---
+      // --- frame, bob, and sleep flag for the current mode ---
       let bob = 0;
       let isSleeping = false;
 
       switch (cat.mode) {
         case 'walk': {
-          // A real gait: two stride silhouettes (legs extended <-> gathering)
-          // swap on the step beat, and the noise re-rolls between swaps so the
-          // texture crawls like fur catching light.
-          const stride = Math.floor(now / CAT_MOTION.STEP_INTERVAL) % 2;
-          const bucket = Math.floor(now / CAT_MOTION.SHIMMER_WALK);
-          show(`walk-${bucket}`, () =>
-            renderCat(stride === 0 ? CAT_MASK_WALK_A : CAT_MASK_WALK_B, Math.random),
-          );
-          bob = -Math.abs(Math.sin(now * Math.PI * CAT_MOTION.BOB_RATE)) * CAT_MOTION.BOB_HEIGHT;
-          break;
-        }
-        case 'rise':
-          // Up on all fours, already turned toward where she's headed.
-          facing = Math.sign(cat.targetX - cat.x) > 0 ? -1 : 1;
-          show('stand', () => renderCat(CAT_MASK_STAND, Math.random));
-          break;
-        case 'settle':
-          // Standing beat again on arrival; she turns back to the reference
-          // orientation here, where flipping the noise is imperceptible.
-          facing = 1;
-          show('stand', () => renderCat(CAT_MASK_STAND, Math.random));
-          break;
-        case 'flick': {
-          // Tail tip up, tail tip down - the reference art, wiggling only its
-          // last two rows on a slow beat.
-          const phase = Math.floor(now / CAT_MOTION.FLICK_INTERVAL) % 2;
-          facing = 1;
-          show(phase === 0 ? 'flick' : 'sit', () =>
-            phase === 0 ? CAT_SIT_ART_FLICK : CAT_SIT_ART,
-          );
+          // The 8-frame leg cycle for her heading, keyed to ground covered -
+          // one stride's worth of pixels per cycle - so planted paws grip
+          // the floor instead of sliding under her. Each frame swap re-rolls
+          // the noise, so the fur shimmers as she moves.
+          walkPx += CAT_MOTION.WALK_SPEED * 0.016 * width;
+          const colPx = (catRef.current?.offsetWidth ?? 0) / WALK_MASK_WIDTH;
+          const phase = colPx > 0 ? (walkPx / (WALK_CYCLE_COLS * colPx)) % 1 : 0;
+          const frames = WALK_MASKS[facing];
+          const bucket = Math.floor(phase * frames.length) % frames.length;
+          show(`walk-${facing}-${bucket}`, frames[bucket]);
+          bob = -Math.abs(Math.sin(phase * Math.PI * 2)) * CAT_MOTION.BOB_HEIGHT;
           break;
         }
         case 'sleep':
-          // Perfectly still; the drifting zzz does the animating.
-          facing = 1;
-          show('sit', () => CAT_SIT_ART);
+          // Perfectly still - one roll, no shimmer; the drifting zzz animates.
+          show(`sleep-${facing}`, SIT_MASKS[facing]);
           isSleeping = true;
           break;
-        case 'alert':
-          // The tail-tip lift is the twitch of noticing.
-          facing = 1;
-          show('flick', () => CAT_SIT_ART_FLICK);
+        case 'alert': {
+          // Noticing: the fur ripples fast for a beat before she sets off.
+          const bucket = Math.floor(now / 0.18);
+          show(`alert-${facing}-${bucket}`, SIT_MASKS[facing]);
           break;
+        }
         case 'sit':
-        default:
-          // Exactly the reference: same glyphs, same orientation. However she
-          // arrived, she turns to settle the way the art was drawn.
-          facing = 1;
-          show('sit', () => CAT_SIT_ART);
+        default: {
+          // Sitting idle: a slow shimmer - the coat re-rolls and breathes.
+          const bucket = Math.floor(now / CAT_MOTION.SIT_SHIMMER);
+          show(`sit-${facing}-${bucket}`, SIT_MASKS[facing]);
           break;
+        }
       }
 
-      // --- paint position + facing (cheap: no React involved) ---
-      // Facing flips the inner art wrapper, not the sprite itself, so the
-      // floating "zzz" never renders mirrored.
+      // --- paint position + bob (cheap: no React involved) ---
       if (catRef.current && width > 0) {
         const px = Math.min(cat.x * width, maxLeft());
         catRef.current.style.transform = `translate3d(${px}px, ${bob}px, 0)`;
-      }
-      if (artRef.current) {
-        artRef.current.style.transform = `scaleX(${facing})`;
-        // The zzz counter-flips against this so its glyphs never mirror.
-        artRef.current.style.setProperty('--cat-facing', String(facing));
       }
 
       if (isSleeping !== currentSleeping) {
@@ -280,7 +238,6 @@ export default function CatPlayground() {
         transition={{ duration: ANIMATION_DURATION.NORMAL }}
       >
         <header className={styles['cat__intro']}>
-          <p className={styles['cat__kicker']}>{CAT.KICKER}</p>
           <h1 className={styles['cat__title']}>{CAT.TITLE_MAIN}</h1>
           <p className={styles['cat__lead']}>{CAT.LEAD}</p>
         </header>
@@ -303,7 +260,7 @@ export default function CatPlayground() {
               .join(' ')}
             aria-hidden="true"
           >
-            <span ref={artRef} className={styles['cat__art']}>
+            <span className={styles['cat__art']}>
               {sleeping && <span className={styles['cat__zzz']}>z&#8202;z&#8202;z</span>}
               {art.join('\n')}
             </span>

--- a/client/src/shared/constants/strings.ts
+++ b/client/src/shared/constants/strings.ts
@@ -94,6 +94,20 @@ export const NOT_FOUND = {
   CONSOLE_SUFFIX: ' - solvable, like everything else. try victoria.maze()',
 } as const;
 
+// /cat - the one page with no agenda. A character-art cat wanders, sits, grooms,
+// and naps; click the floor and it comes over. The senior signal is restraint:
+// same monochrome mono language as the rest, respects prefers-reduced-motion,
+// and never begs for attention.
+export const CAT = {
+  DOC_TITLE: 'The cat | Victoria Kirichenko',
+  KICKER: 'CAT.EXE',
+  TITLE_MAIN: 'Off the clock.',
+  LEAD: 'Every system that scales needs somewhere to put the pressure down. This is mine.',
+  HINT: '// click the floor - she comes when she feels like it',
+  BACK_ACTION: 'Back to the serious stuff',
+  CONSOLE_LINE: '// meow. (it works, that was the whole point.)',
+} as const;
+
 // Console Messages
 export const CONSOLE_MESSAGES = {
   WELCOME_TITLE: "🚀 Welcome to Victoria Kirichenko's Portfolio!",
@@ -179,8 +193,10 @@ export const CONSOLE_SDK = {
     { command: 'victoria.skills()', what: 'the tech arsenal' },
     { command: 'victoria.hire()', what: 'why we should talk' },
     { command: 'victoria.contact()', what: 'reach me directly' },
+    { command: 'victoria.cat()', what: 'everything serious needs a way out' },
   ],
   HELP_RETURN: '↑ call any command, e.g. victoria.readme()',
+  CAT_RETURN: 'off you go →',
 
   README_SECTIONS: [
     {

--- a/client/src/shared/constants/strings.ts
+++ b/client/src/shared/constants/strings.ts
@@ -100,7 +100,6 @@ export const NOT_FOUND = {
 // and never begs for attention.
 export const CAT = {
   DOC_TITLE: 'The cat | Victoria Kirichenko',
-  KICKER: 'CAT.EXE',
   TITLE_MAIN: 'Off the clock.',
   LEAD: 'Every system that scales needs somewhere to put the pressure down. This is mine.',
   HINT: '// click the floor - she comes when she feels like it',

--- a/client/src/shared/lib/console-signature.ts
+++ b/client/src/shared/lib/console-signature.ts
@@ -204,6 +204,15 @@ function buildApi() {
       line(`  Location  ${PERSONAL_INFO.LOCATION}`, STYLE.body);
       close(CONSOLE_SDK.CONTACT_RETURN);
     },
+    // The way out. Client-side nav to /cat: push the URL, then let wouter's
+    // popstate listener pick it up - no full reload, no lost console.
+    cat() {
+      if (typeof window !== 'undefined') {
+        window.history.pushState({}, '', '/cat');
+        window.dispatchEvent(new PopStateEvent('popstate'));
+      }
+      close(CONSOLE_SDK.CAT_RETURN);
+    },
   };
 
   // Stringify to a clean one-liner (e.g. `${victoria}`) instead of "[object Object]".


### PR DESCRIPTION
## What changed

Replaces the /cat page's hand-drawn frame art with the glyph-texture look from the new reference renders:

- **Baked silhouette masks** (`'#'` grids) generated offline from ellipse/polygon/tapered-stroke geometry: a 44-row sitting pose and a 40-row walking body with a plume tail. Both face left natively; right-facing sets are exact horizontal mirrors, matching the two directions in the references.
- **Per-frame glyph noise fill** (`renderCat`): heavy digits (`9 8 S $ 5`) in the coat, light punctuation on silhouette edges, ~10% dropout for the felty holes, and fur wisps sprouting just outside the mask - so the fur shimmers on every frame swap. A punched hole in the head mask reads as the dark eye.
- **8-frame lateral-walk gait per direction**, still keyed to ground distance so planted paws grip instead of sliding.
- **Simpler state machine**: the rise/settle keyframe sequences are gone; she sits facing her last direction of travel, sitting idle "breathes" via slow noise re-rolls, alert ripples the fur faster before she sets off.
- **Removed the CAT.EXE kicker** from the page header (constant, markup, and CSS rule).

## Why

The page's cat art was redrawn to match a new set of reference renders - a fluffy long-haired cat rendered as dense character noise rather than outline sketch work.

## Notes for review

- The mask literals in `cat-frames.ts` are generated output; the gait/leg code and `renderCat` are the parts worth reading.
- Verified live: sitting (both facings), walking (both directions), sleep/zzz, reduced-motion still renders a single still frame. `tsc` and lint hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)