### PR TITLE
docs(architecture): resync the layout tree, log /cat and print-resume

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,9 +6,9 @@ Lightweight decision log for the portfolio. One page, static output, no server.
 
 ```
 client/
-  index.html          document shell: SEO meta, JSON-LD, font links, LCP preload
+  index.html          document shell: SEO meta, JSON-LD, font + LCP preloads
   public/             static assets copied verbatim into the build
-                      (CNAME, favicons, og-preview.png, victoria-portrait.webp)
+                      (CNAME, favicons, fonts/, og-preview.png, portraits)
   src/
     app/              main.tsx entry → App.tsx (MotionConfig, CursorGlow, router)
                       + index.css (Tailwind layers, cascade order)
@@ -17,21 +17,28 @@ client/
     features/         one folder per section: hero, about (+ geometric-
                       wireframe), experience, philosophy (+ tangle-to-clarity),
                       projects, testimonials (+ slack-testimonials), contact,
-                      footer, not-found (lazy-loaded 404 chunk) — components
-                      used by exactly one section live in that section's folder
+                      footer - components used by exactly one section live in
+                      that section's folder. Non-section features: not-found
+                      (lazy 404 chunk + suggest-sections.ts), cat (lazy /cat
+                      chunk: cat-frames.ts + cat-playground.tsx), print-resume
+                      (the Cmd+P one-page document)
     shared/
       components/     cross-feature pieces (navigation, code-background,
                       scroll-reveal, section-title, particle-system,
-                      cursor-glow) + ui/card (shadcn)
+                      cursor-glow, scramble-text)
       hooks/          use-scroll-reveal
       constants/      strings.ts (all copy/content) · layout.ts (animation
                       numbers) · colors.ts (console palette)
-      styles/         tokens.css — design tokens (single source for
-                      colors/spacing/type/etc.)
-      lib/            utils.ts (cn) · console-signature.ts (easter egg)
+      styles/         tokens.css - design tokens (single source for
+                      colors/spacing/type/etc.) · fonts.css (generated
+                      @font-face rules; see scripts/gen-fonts.mjs)
+      lib/            console-signature.ts (easter egg) · maze.ts (+ test) -
+                      the generator behind victoria.maze() and the 404 maze
     test/             vitest setup + smoke tests
 assets/               image sources of truth (not shipped as-is)
-scripts/              sharp pipelines: gen-portrait.mjs, gen-icons.mjs
+scripts/              sharp pipelines: gen-portrait.mjs, gen-icons.mjs,
+                      gen-og.mjs · gen-fonts.mjs (vendors woff2) ·
+                      visual-diff.mjs (pixel-diff regression harness)
 ```
 
 ## Decisions
@@ -42,7 +49,7 @@ builds `public/` from source on every push; build output is not committed.
 
 **CSS Modules with classic BEM names.** Modules provide the isolation, BEM
 provides the readability: every class is `block__element--modifier` with
-kebab-case words, so a name always says which component owns it — in source,
+kebab-case words, so a name always says which component owns it - in source,
 in grep, and in devtools (the hash embeds it). This reverses the earlier
 "write new classes camelCase" convention (2026-07): by then ~85% of classes
 were already BEM and the blocks map 1:1 to the feature folders, so finishing
@@ -73,8 +80,26 @@ index.css).
 
 **LCP image strategy.** The portrait ships as a stable-named WebP in
 `client/public/` (not a hashed import) so `index.html` can `<link rel="preload">`
-it — with a hashed JS import the browser couldn't discover it until the bundle
+it - with a hashed JS import the browser couldn't discover it until the bundle
 executed, which put baseline LCP at 20 s.
+
+**`/cat` is a route, not a section.** The ASCII cat is an easter egg reached
+from the console (`victoria.cat()`), so it gets its own lazy chunk alongside
+not-found: a hidden gem shouldn't weigh on the homepage's critical path. It
+lives in `features/` rather than `pages/` because it's one self-contained
+component, not a composition of sections. Frames are baked silhouette masks
+refilled with fresh glyph noise each render (`cat-frames.ts`), so the fur
+shimmers without shipping a sprite sheet per pose.
+
+**Print is a separate document, not print styles on the live page.** The
+interactive layout can't reflow to one page, so `features/print-resume` renders
+a parallel one-page resume and `home.module.css` swaps the two under
+`@media print`. It reads the same constants the live sections do
+(`EXPERIENCE_LOG`, `ABOUT_IMPACT`, ...), so print can't drift from the page.
+Unlike `/cat` it is _not_ lazy: Cmd+P fires with no time to fetch a chunk, so it
+ships in the main bundle. It carries `aria-hidden` as well as `display: none`,
+since the duplicate `h1` must stay out of the a11y tree where the print CSS
+doesn't apply (jsdom in tests).
 
 **Cascade order** (index.css): tokens import → Tailwind base/components/
 utilities layers → shadcn variable block → `@layer base` element styles →

--- a/client/src/shared/constants/strings.ts
+++ b/client/src/shared/constants/strings.ts
@@ -356,9 +356,9 @@ export const ABOUT_APPROACH = [
 ] as const;
 
 // Experience Section - rendered as a `git log --graph` of the career.
-// `shape` drives the commit-graph gutter (see home.tsx): the Perion promotion
-// is a real merge - the full-stack track branches off and merges into the
-// leadership line. `type` is the conventional-commit verb shown before the role.
+// `shape` drives the commit-graph gutter (see features/experience): the Perion
+// promotion is a real merge - the full-stack track branches off and merges into
+// the leadership line. `type` is the conventional-commit verb shown before the role.
 type ExperienceCommit = {
   hash: string;
   type: 'feat' | 'merge' | 'init';
@@ -449,8 +449,8 @@ export const EXPERIENCE_LOG: readonly ExperienceCommit[] = [
 ];
 
 // Testimonials Section
-// Rendered as an initials-selector (see home.tsx): the initials discs act as a
-// picker and a single quote shows at a time. Quotes are trimmed to their
+// Rendered as an initials-selector (see features/testimonials): the initials discs
+// act as a picker and a single quote shows at a time. Quotes are trimmed to their
 // sharpest line; the full recommendations live on LinkedIn.
 type Testimonial = {
   quote: string;


### PR DESCRIPTION
The Layout tree had drifted from client/src. features/ omitted cat and print-resume; shared/components/ omitted scramble-text while still claiming ui/card (shadcn); shared/lib/ still listed utils.ts (cn) and not maze.ts - both of those paths are gone. The same block also missed fonts.css, three of the five scripts, and still described the fonts as external links.

Adds Decisions entries for the two features where a real call was made: /cat as a lazy route rather than a section, and print-resume as a parallel document that deliberately is not lazy.

strings.ts: two "see home.tsx" comments now point at features/experience and features/testimonials, where the rendering actually lives.